### PR TITLE
Re-enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+


### PR DESCRIPTION
This project is no longer showing dependabot as being configured. This has been seen in other projects as well and the recommendation from GitHub support is to make any change to the config file and it should start working again.