### PR TITLE
Include AST issues display string in compilation error

### DIFF
--- a/src/main/java/build/buf/protovalidate/internal/expression/AstExpression.java
+++ b/src/main/java/build/buf/protovalidate/internal/expression/AstExpression.java
@@ -45,7 +45,8 @@ public class AstExpression {
       throws CompilationException {
     Env.AstIssuesTuple astIssuesTuple = env.compile(expr.expression);
     if (astIssuesTuple.hasIssues()) {
-      throw new CompilationException("Failed to compile expression " + expr.id);
+      throw new CompilationException(
+          "Failed to compile expression " + expr.id + ":\n" + astIssuesTuple.getIssues());
     }
     Ast ast = astIssuesTuple.getAst();
     Type outType = ast.getResultType();


### PR DESCRIPTION
Including the errors from the compiler makes it easier to find and fix errors. For example this signed-versus-unsigned type error:

```
build.buf.protovalidate.exceptions.CompilationException: Failed to compile expression id.non_zero:
ERROR: <input>:1:28: found no matching overload for '_!=_' applied to '(uint, int)'
 | this.most_significant_bits != 0 || this.least_significant_bits != 0u
 | ...........................^
```