### PR TITLE
Update generated code to protoc v24.3

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,5 +2,5 @@ version: v1
 managed:
   enabled: false
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: buf.build/protocolbuffers/java:v24.3
     out: src/main/java

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
     `version-catalog`
 
     `java-library`
-    alias(libs.plugins.errorprone.plugin)
-    id("com.vanniktech.maven.publish.base") version "0.25.3"
+    alias(libs.plugins.errorprone)
+    alias(libs.plugins.maven)
 }
 
 java {
@@ -22,6 +22,8 @@ tasks.withType<JavaCompile> {
     if (JavaVersion.current().isJava9Compatible) doFirst {
         options.compilerArgs = mutableListOf("--release", "8")
     }
+    // Disable errorprone on generated code
+    options.errorprone.excludedPaths.set(".*/src/main/java/build/buf/validate/.*")
     if (!name.lowercase().contains("test")) {
         options.errorprone {
             check("NullAway", CheckSeverity.ERROR)
@@ -31,9 +33,8 @@ tasks.withType<JavaCompile> {
 }
 
 tasks.withType<Javadoc> {
-    // TODO: Enable when Javadoc changes are final
-//    val stdOptions = options as StandardJavadocDocletOptions
-//    stdOptions.addBooleanOption("Xwerror", true)
+    val stdOptions = options as StandardJavadocDocletOptions
+    stdOptions.addBooleanOption("Xwerror", true)
 }
 
 tasks.withType<GenerateModuleMetadata> {

--- a/conformance/buf.gen.yaml
+++ b/conformance/buf.gen.yaml
@@ -3,5 +3,5 @@ managed:
   enabled: true
   java_package_prefix: "build"
 plugins:
-  - plugin: buf.build/protocolbuffers/java:v23.4
+  - plugin: buf.build/protocolbuffers/java:v24.3
     out: src/main/java

--- a/conformance/build.gradle.kts
+++ b/conformance/build.gradle.kts
@@ -1,10 +1,19 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
+import net.ltgt.gradle.errorprone.errorprone
 
 plugins {
     `version-catalog`
 
     java
-    alias(libs.plugins.errorprone.plugin)
+    alias(libs.plugins.errorprone)
+}
+
+tasks.withType<JavaCompile> {
+    if (JavaVersion.current().isJava9Compatible) doFirst {
+        options.compilerArgs = mutableListOf("--release", "8")
+    }
+    // Disable errorprone on generated code
+    options.errorprone.excludedPaths.set(".*/src/main/java/build/buf/validate/conformance/.*")
 }
 
 // Disable javadoc for conformance tests

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/AnyIn.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/AnyIn.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.AnyIn.class, build.buf.validate.conformance.cases.AnyIn.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Any val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Any val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.AnyIn.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.AnyIn result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/AnyNone.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/AnyNone.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.AnyNone.class, build.buf.validate.conformance.cases.AnyNone.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Any val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Any val = 1 [json_name = "val"];</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.AnyNone.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.AnyNone result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/AnyNotIn.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/AnyNotIn.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.AnyNotIn.class, build.buf.validate.conformance.cases.AnyNotIn.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Any val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Any val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.AnyNotIn.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.AnyNotIn result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/AnyRequired.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/AnyRequired.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.AnyRequired.class, build.buf.validate.conformance.cases.AnyRequired.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Any val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Any val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.AnyRequired.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.AnyRequired result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/ComplexTestMsg.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/ComplexTestMsg.java
@@ -54,6 +54,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.ComplexTestMsg.class, build.buf.validate.conformance.cases.ComplexTestMsg.Builder.class);
   }
 
+  private int bitField0_;
   private int oCase_ = 0;
   @SuppressWarnings("serial")
   private java.lang.Object o_;
@@ -143,7 +144,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasNested() {
-    return nested_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.ComplexTestMsg nested = 2 [json_name = "nested"];</code>
@@ -191,7 +192,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasFloatVal() {
-    return floatVal_ != null;
+    return ((bitField0_ & 0x00000002) != 0);
   }
   /**
    * <code>.google.protobuf.FloatValue float_val = 5 [json_name = "floatVal", (.buf.validate.field) = { ... }</code>
@@ -217,7 +218,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasDurVal() {
-    return durVal_ != null;
+    return ((bitField0_ & 0x00000004) != 0);
   }
   /**
    * <code>.google.protobuf.Duration dur_val = 6 [json_name = "durVal", (.buf.validate.field) = { ... }</code>
@@ -243,7 +244,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasTsVal() {
-    return tsVal_ != null;
+    return ((bitField0_ & 0x00000008) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp ts_val = 7 [json_name = "tsVal", (.buf.validate.field) = { ... }</code>
@@ -269,7 +270,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasAnother() {
-    return another_ != null;
+    return ((bitField0_ & 0x00000010) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.ComplexTestMsg another = 8 [json_name = "another"];</code>
@@ -335,7 +336,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasAnyVal() {
-    return anyVal_ != null;
+    return ((bitField0_ & 0x00000020) != 0);
   }
   /**
    * <code>.google.protobuf.Any any_val = 12 [json_name = "anyVal", (.buf.validate.field) = { ... }</code>
@@ -574,7 +575,7 @@ java.lang.String defaultValue) {
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(const_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, const_);
     }
-    if (nested_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(2, getNested());
     }
     if (intConst_ != 0) {
@@ -583,16 +584,16 @@ java.lang.String defaultValue) {
     if (boolConst_ != false) {
       output.writeBool(4, boolConst_);
     }
-    if (floatVal_ != null) {
+    if (((bitField0_ & 0x00000002) != 0)) {
       output.writeMessage(5, getFloatVal());
     }
-    if (durVal_ != null) {
+    if (((bitField0_ & 0x00000004) != 0)) {
       output.writeMessage(6, getDurVal());
     }
-    if (tsVal_ != null) {
+    if (((bitField0_ & 0x00000008) != 0)) {
       output.writeMessage(7, getTsVal());
     }
-    if (another_ != null) {
+    if (((bitField0_ & 0x00000010) != 0)) {
       output.writeMessage(8, getAnother());
     }
     if (java.lang.Float.floatToRawIntBits(floatConst_) != 0) {
@@ -604,7 +605,7 @@ java.lang.String defaultValue) {
     if (enumConst_ != build.buf.validate.conformance.cases.ComplexTestEnum.COMPLEX_TEST_ENUM_UNSPECIFIED.getNumber()) {
       output.writeEnum(11, enumConst_);
     }
-    if (anyVal_ != null) {
+    if (((bitField0_ & 0x00000020) != 0)) {
       output.writeMessage(12, getAnyVal());
     }
     for (int i = 0; i < repTsVal_.size(); i++) {
@@ -638,7 +639,7 @@ java.lang.String defaultValue) {
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(const_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, const_);
     }
-    if (nested_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(2, getNested());
     }
@@ -650,19 +651,19 @@ java.lang.String defaultValue) {
       size += com.google.protobuf.CodedOutputStream
         .computeBoolSize(4, boolConst_);
     }
-    if (floatVal_ != null) {
+    if (((bitField0_ & 0x00000002) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(5, getFloatVal());
     }
-    if (durVal_ != null) {
+    if (((bitField0_ & 0x00000004) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(6, getDurVal());
     }
-    if (tsVal_ != null) {
+    if (((bitField0_ & 0x00000008) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(7, getTsVal());
     }
-    if (another_ != null) {
+    if (((bitField0_ & 0x00000010) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(8, getAnother());
     }
@@ -678,7 +679,7 @@ java.lang.String defaultValue) {
       size += com.google.protobuf.CodedOutputStream
         .computeEnumSize(11, enumConst_);
     }
-    if (anyVal_ != null) {
+    if (((bitField0_ & 0x00000020) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(12, getAnyVal());
     }
@@ -998,13 +999,25 @@ java.lang.String defaultValue) {
 
     // Construct using build.buf.validate.conformance.cases.ComplexTestMsg.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getNestedFieldBuilder();
+        getFloatValFieldBuilder();
+        getDurValFieldBuilder();
+        getTsValFieldBuilder();
+        getAnotherFieldBuilder();
+        getAnyValFieldBuilder();
+        getRepTsValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -1107,10 +1120,12 @@ java.lang.String defaultValue) {
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.nested_ = nestedBuilder_ == null
             ? nested_
             : nestedBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
       if (((from_bitField0_ & 0x00000004) != 0)) {
         result.intConst_ = intConst_;
@@ -1122,21 +1137,25 @@ java.lang.String defaultValue) {
         result.floatVal_ = floatValBuilder_ == null
             ? floatVal_
             : floatValBuilder_.build();
+        to_bitField0_ |= 0x00000002;
       }
       if (((from_bitField0_ & 0x00000020) != 0)) {
         result.durVal_ = durValBuilder_ == null
             ? durVal_
             : durValBuilder_.build();
+        to_bitField0_ |= 0x00000004;
       }
       if (((from_bitField0_ & 0x00000040) != 0)) {
         result.tsVal_ = tsValBuilder_ == null
             ? tsVal_
             : tsValBuilder_.build();
+        to_bitField0_ |= 0x00000008;
       }
       if (((from_bitField0_ & 0x00000080) != 0)) {
         result.another_ = anotherBuilder_ == null
             ? another_
             : anotherBuilder_.build();
+        to_bitField0_ |= 0x00000010;
       }
       if (((from_bitField0_ & 0x00000100) != 0)) {
         result.floatConst_ = floatConst_;
@@ -1151,6 +1170,7 @@ java.lang.String defaultValue) {
         result.anyVal_ = anyValBuilder_ == null
             ? anyVal_
             : anyValBuilder_.build();
+        to_bitField0_ |= 0x00000020;
       }
       if (((from_bitField0_ & 0x00002000) != 0)) {
         result.mapVal_ = internalGetMapVal();
@@ -1159,6 +1179,7 @@ java.lang.String defaultValue) {
       if (((from_bitField0_ & 0x00004000) != 0)) {
         result.bytesVal_ = bytesVal_;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     private void buildPartialOneofs(build.buf.validate.conformance.cases.ComplexTestMsg result) {
@@ -1601,8 +1622,10 @@ java.lang.String defaultValue) {
       } else {
         nestedBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000002;
-      onChanged();
+      if (nested_ != null) {
+        bitField0_ |= 0x00000002;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -1784,8 +1807,10 @@ java.lang.String defaultValue) {
       } else {
         floatValBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000010;
-      onChanged();
+      if (floatVal_ != null) {
+        bitField0_ |= 0x00000010;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -1903,8 +1928,10 @@ java.lang.String defaultValue) {
       } else {
         durValBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000020;
-      onChanged();
+      if (durVal_ != null) {
+        bitField0_ |= 0x00000020;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -2022,8 +2049,10 @@ java.lang.String defaultValue) {
       } else {
         tsValBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000040;
-      onChanged();
+      if (tsVal_ != null) {
+        bitField0_ |= 0x00000040;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -2141,8 +2170,10 @@ java.lang.String defaultValue) {
       } else {
         anotherBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000080;
-      onChanged();
+      if (another_ != null) {
+        bitField0_ |= 0x00000080;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -2377,8 +2408,10 @@ java.lang.String defaultValue) {
       } else {
         anyValBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000800;
-      onChanged();
+      if (anyVal_ != null) {
+        bitField0_ |= 0x00000800;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationConst.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationConst.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationConst.class, build.buf.validate.conformance.cases.DurationConst.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationConst.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationConst result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationExGTELTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationExGTELTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationExGTELTE.class, build.buf.validate.conformance.cases.DurationExGTELTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationExGTELTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationExGTELTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationExLTGT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationExLTGT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationExLTGT.class, build.buf.validate.conformance.cases.DurationExLTGT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationExLTGT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationExLTGT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationFieldWithOtherFields.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationFieldWithOtherFields.java
@@ -43,6 +43,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationFieldWithOtherFields.class, build.buf.validate.conformance.cases.DurationFieldWithOtherFields.Builder.class);
   }
 
+  private int bitField0_;
   public static final int DURATION_VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration durationVal_;
   /**
@@ -51,7 +52,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasDurationVal() {
-    return durationVal_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration duration_val = 1 [json_name = "durationVal", (.buf.validate.field) = { ... }</code>
@@ -94,7 +95,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (durationVal_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getDurationVal());
     }
     if (intVal_ != 0) {
@@ -109,7 +110,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (durationVal_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getDurationVal());
     }
@@ -280,13 +281,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationFieldWithOtherFields.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getDurationValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -331,14 +338,17 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationFieldWithOtherFields result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.durationVal_ = durationValBuilder_ == null
             ? durationVal_
             : durationValBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.intVal_ = intVal_;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -512,8 +522,10 @@ private static final long serialVersionUID = 0L;
       } else {
         durationValBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (durationVal_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationGT.class, build.buf.validate.conformance.cases.DurationGT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationGT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationGT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationGTE.class, build.buf.validate.conformance.cases.DurationGTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationGTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationGTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGTELTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGTELTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationGTELTE.class, build.buf.validate.conformance.cases.DurationGTELTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationGTELTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationGTELTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGTLT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationGTLT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationGTLT.class, build.buf.validate.conformance.cases.DurationGTLT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationGTLT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationGTLT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationIn.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationIn.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationIn.class, build.buf.validate.conformance.cases.DurationIn.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationIn.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationIn result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationLT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationLT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationLT.class, build.buf.validate.conformance.cases.DurationLT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationLT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationLT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationLTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationLTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationLTE.class, build.buf.validate.conformance.cases.DurationLTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationLTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationLTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationNone.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationNone.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationNone.class, build.buf.validate.conformance.cases.DurationNone.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val"];</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationNone.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationNone result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationNotIn.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationNotIn.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationNotIn.class, build.buf.validate.conformance.cases.DurationNotIn.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationNotIn.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationNotIn result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/DurationRequired.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/DurationRequired.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.DurationRequired.class, build.buf.validate.conformance.cases.DurationRequired.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Duration val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Duration val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.DurationRequired.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.DurationRequired result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/KitchenSinkMessage.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/KitchenSinkMessage.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.KitchenSinkMessage.class, build.buf.validate.conformance.cases.KitchenSinkMessage.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private build.buf.validate.conformance.cases.ComplexTestMsg val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.ComplexTestMsg val = 1 [json_name = "val"];</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.KitchenSinkMessage.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.KitchenSinkMessage result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/Message.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/Message.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.Message.class, build.buf.validate.conformance.cases.Message.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private build.buf.validate.conformance.cases.TestMsg val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.TestMsg val = 1 [json_name = "val"];</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.Message.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.Message result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/MessageCrossPackage.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/MessageCrossPackage.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.MessageCrossPackage.class, build.buf.validate.conformance.cases.MessageCrossPackage.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private build.buf.validate.conformance.cases.other_package.Embed val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.other_package.Embed val = 1 [json_name = "val"];</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.MessageCrossPackage.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.MessageCrossPackage result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/MessageNone.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/MessageNone.java
@@ -435,6 +435,7 @@ private static final long serialVersionUID = 0L;
 
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private build.buf.validate.conformance.cases.MessageNone.NoneMsg val_;
   /**
@@ -443,7 +444,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.MessageNone.NoneMsg val = 1 [json_name = "val"];</code>
@@ -475,7 +476,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -487,7 +488,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -645,13 +646,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.MessageNone.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -695,11 +702,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.MessageNone result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -865,8 +875,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/MessageRequired.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/MessageRequired.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.MessageRequired.class, build.buf.validate.conformance.cases.MessageRequired.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private build.buf.validate.conformance.cases.TestMsg val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.TestMsg val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.MessageRequired.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.MessageRequired result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/MessageRequiredButOptional.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/MessageRequiredButOptional.java
@@ -478,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/MessageSkip.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/MessageSkip.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.MessageSkip.class, build.buf.validate.conformance.cases.MessageSkip.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private build.buf.validate.conformance.cases.TestMsg val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.TestMsg val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.MessageSkip.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.MessageSkip result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedExact.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedExact.java
@@ -41,7 +41,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int VAL_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList val_;
+  private com.google.protobuf.Internal.IntList val_ =
+      emptyIntList();
   /**
    * <code>repeated uint32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
    * @return A list containing the val.
@@ -303,22 +304,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.conformance.cases.RepeatedExact buildPartial() {
       build.buf.validate.conformance.cases.RepeatedExact result = new build.buf.validate.conformance.cases.RepeatedExact(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(build.buf.validate.conformance.cases.RepeatedExact result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        val_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.val_ = val_;
-    }
-
     private void buildPartial0(build.buf.validate.conformance.cases.RepeatedExact result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        val_.makeImmutable();
+        result.val_ = val_;
+      }
     }
 
     @java.lang.Override
@@ -368,7 +364,8 @@ private static final long serialVersionUID = 0L;
       if (!other.val_.isEmpty()) {
         if (val_.isEmpty()) {
           val_ = other.val_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          val_.makeImmutable();
+          bitField0_ |= 0x00000001;
         } else {
           ensureValIsMutable();
           val_.addAll(other.val_);
@@ -436,10 +433,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList val_ = emptyIntList();
     private void ensureValIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
-        val_ = mutableCopy(val_);
-        bitField0_ |= 0x00000001;
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_);
       }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <code>repeated uint32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -447,8 +444,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getValList() {
-      return ((bitField0_ & 0x00000001) != 0) ?
-               java.util.Collections.unmodifiableList(val_) : val_;
+      val_.makeImmutable();
+      return val_;
     }
     /**
      * <code>repeated uint32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -476,6 +473,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.setInt(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -488,6 +486,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.addInt(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -501,6 +500,7 @@ private static final long serialVersionUID = 0L;
       ensureValIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, val_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedExactIgnore.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedExactIgnore.java
@@ -41,7 +41,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int VAL_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList val_;
+  private com.google.protobuf.Internal.IntList val_ =
+      emptyIntList();
   /**
    * <code>repeated uint32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
    * @return A list containing the val.
@@ -303,22 +304,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.conformance.cases.RepeatedExactIgnore buildPartial() {
       build.buf.validate.conformance.cases.RepeatedExactIgnore result = new build.buf.validate.conformance.cases.RepeatedExactIgnore(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(build.buf.validate.conformance.cases.RepeatedExactIgnore result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        val_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.val_ = val_;
-    }
-
     private void buildPartial0(build.buf.validate.conformance.cases.RepeatedExactIgnore result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        val_.makeImmutable();
+        result.val_ = val_;
+      }
     }
 
     @java.lang.Override
@@ -368,7 +364,8 @@ private static final long serialVersionUID = 0L;
       if (!other.val_.isEmpty()) {
         if (val_.isEmpty()) {
           val_ = other.val_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          val_.makeImmutable();
+          bitField0_ |= 0x00000001;
         } else {
           ensureValIsMutable();
           val_.addAll(other.val_);
@@ -436,10 +433,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList val_ = emptyIntList();
     private void ensureValIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
-        val_ = mutableCopy(val_);
-        bitField0_ |= 0x00000001;
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_);
       }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <code>repeated uint32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -447,8 +444,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getValList() {
-      return ((bitField0_ & 0x00000001) != 0) ?
-               java.util.Collections.unmodifiableList(val_) : val_;
+      val_.makeImmutable();
+      return val_;
     }
     /**
      * <code>repeated uint32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -476,6 +473,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.setInt(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -488,6 +486,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.addInt(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -501,6 +500,7 @@ private static final long serialVersionUID = 0L;
       ensureValIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, val_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedItemRule.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedItemRule.java
@@ -41,7 +41,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int VAL_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.FloatList val_;
+  private com.google.protobuf.Internal.FloatList val_ =
+      emptyFloatList();
   /**
    * <code>repeated float val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
    * @return A list containing the val.
@@ -300,22 +301,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.conformance.cases.RepeatedItemRule buildPartial() {
       build.buf.validate.conformance.cases.RepeatedItemRule result = new build.buf.validate.conformance.cases.RepeatedItemRule(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(build.buf.validate.conformance.cases.RepeatedItemRule result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        val_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.val_ = val_;
-    }
-
     private void buildPartial0(build.buf.validate.conformance.cases.RepeatedItemRule result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        val_.makeImmutable();
+        result.val_ = val_;
+      }
     }
 
     @java.lang.Override
@@ -365,7 +361,8 @@ private static final long serialVersionUID = 0L;
       if (!other.val_.isEmpty()) {
         if (val_.isEmpty()) {
           val_ = other.val_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          val_.makeImmutable();
+          bitField0_ |= 0x00000001;
         } else {
           ensureValIsMutable();
           val_.addAll(other.val_);
@@ -407,7 +404,8 @@ private static final long serialVersionUID = 0L;
             case 10: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureValIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureValIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 val_.addFloat(input.readFloat());
               }
@@ -433,10 +431,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.FloatList val_ = emptyFloatList();
     private void ensureValIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
-        val_ = mutableCopy(val_);
-        bitField0_ |= 0x00000001;
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_);
       }
+      bitField0_ |= 0x00000001;
+    }
+    private void ensureValIsMutable(int capacity) {
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_, capacity);
+      }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <code>repeated float val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -444,8 +448,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Float>
         getValList() {
-      return ((bitField0_ & 0x00000001) != 0) ?
-               java.util.Collections.unmodifiableList(val_) : val_;
+      val_.makeImmutable();
+      return val_;
     }
     /**
      * <code>repeated float val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -473,6 +477,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.setFloat(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -485,6 +490,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.addFloat(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -498,6 +504,7 @@ private static final long serialVersionUID = 0L;
       ensureValIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, val_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedMax.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedMax.java
@@ -41,7 +41,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int VAL_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.DoubleList val_;
+  private com.google.protobuf.Internal.DoubleList val_ =
+      emptyDoubleList();
   /**
    * <code>repeated double val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
    * @return A list containing the val.
@@ -300,22 +301,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.conformance.cases.RepeatedMax buildPartial() {
       build.buf.validate.conformance.cases.RepeatedMax result = new build.buf.validate.conformance.cases.RepeatedMax(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(build.buf.validate.conformance.cases.RepeatedMax result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        val_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.val_ = val_;
-    }
-
     private void buildPartial0(build.buf.validate.conformance.cases.RepeatedMax result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        val_.makeImmutable();
+        result.val_ = val_;
+      }
     }
 
     @java.lang.Override
@@ -365,7 +361,8 @@ private static final long serialVersionUID = 0L;
       if (!other.val_.isEmpty()) {
         if (val_.isEmpty()) {
           val_ = other.val_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          val_.makeImmutable();
+          bitField0_ |= 0x00000001;
         } else {
           ensureValIsMutable();
           val_.addAll(other.val_);
@@ -407,7 +404,8 @@ private static final long serialVersionUID = 0L;
             case 10: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureValIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureValIsMutable(alloc / 8);
               while (input.getBytesUntilLimit() > 0) {
                 val_.addDouble(input.readDouble());
               }
@@ -433,10 +431,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.DoubleList val_ = emptyDoubleList();
     private void ensureValIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
-        val_ = mutableCopy(val_);
-        bitField0_ |= 0x00000001;
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_);
       }
+      bitField0_ |= 0x00000001;
+    }
+    private void ensureValIsMutable(int capacity) {
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_, capacity);
+      }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <code>repeated double val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -444,8 +448,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Double>
         getValList() {
-      return ((bitField0_ & 0x00000001) != 0) ?
-               java.util.Collections.unmodifiableList(val_) : val_;
+      val_.makeImmutable();
+      return val_;
     }
     /**
      * <code>repeated double val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -473,6 +477,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.setDouble(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -485,6 +490,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.addDouble(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -498,6 +504,7 @@ private static final long serialVersionUID = 0L;
       ensureValIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, val_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedMinMax.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedMinMax.java
@@ -41,7 +41,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int VAL_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList val_;
+  private com.google.protobuf.Internal.IntList val_ =
+      emptyIntList();
   /**
    * <code>repeated sfixed32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
    * @return A list containing the val.
@@ -300,22 +301,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.conformance.cases.RepeatedMinMax buildPartial() {
       build.buf.validate.conformance.cases.RepeatedMinMax result = new build.buf.validate.conformance.cases.RepeatedMinMax(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(build.buf.validate.conformance.cases.RepeatedMinMax result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        val_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.val_ = val_;
-    }
-
     private void buildPartial0(build.buf.validate.conformance.cases.RepeatedMinMax result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        val_.makeImmutable();
+        result.val_ = val_;
+      }
     }
 
     @java.lang.Override
@@ -365,7 +361,8 @@ private static final long serialVersionUID = 0L;
       if (!other.val_.isEmpty()) {
         if (val_.isEmpty()) {
           val_ = other.val_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          val_.makeImmutable();
+          bitField0_ |= 0x00000001;
         } else {
           ensureValIsMutable();
           val_.addAll(other.val_);
@@ -407,7 +404,8 @@ private static final long serialVersionUID = 0L;
             case 10: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureValIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureValIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 val_.addInt(input.readSFixed32());
               }
@@ -433,10 +431,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList val_ = emptyIntList();
     private void ensureValIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
-        val_ = mutableCopy(val_);
-        bitField0_ |= 0x00000001;
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_);
       }
+      bitField0_ |= 0x00000001;
+    }
+    private void ensureValIsMutable(int capacity) {
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_, capacity);
+      }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <code>repeated sfixed32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -444,8 +448,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getValList() {
-      return ((bitField0_ & 0x00000001) != 0) ?
-               java.util.Collections.unmodifiableList(val_) : val_;
+      val_.makeImmutable();
+      return val_;
     }
     /**
      * <code>repeated sfixed32 val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -473,6 +477,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.setInt(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -485,6 +490,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.addInt(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -498,6 +504,7 @@ private static final long serialVersionUID = 0L;
       ensureValIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, val_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedNone.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/RepeatedNone.java
@@ -41,7 +41,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int VAL_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList val_;
+  private com.google.protobuf.Internal.LongList val_ =
+      emptyLongList();
   /**
    * <code>repeated int64 val = 1 [json_name = "val"];</code>
    * @return A list containing the val.
@@ -303,22 +304,17 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.conformance.cases.RepeatedNone buildPartial() {
       build.buf.validate.conformance.cases.RepeatedNone result = new build.buf.validate.conformance.cases.RepeatedNone(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
     }
 
-    private void buildPartialRepeatedFields(build.buf.validate.conformance.cases.RepeatedNone result) {
-      if (((bitField0_ & 0x00000001) != 0)) {
-        val_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000001);
-      }
-      result.val_ = val_;
-    }
-
     private void buildPartial0(build.buf.validate.conformance.cases.RepeatedNone result) {
       int from_bitField0_ = bitField0_;
+      if (((from_bitField0_ & 0x00000001) != 0)) {
+        val_.makeImmutable();
+        result.val_ = val_;
+      }
     }
 
     @java.lang.Override
@@ -368,7 +364,8 @@ private static final long serialVersionUID = 0L;
       if (!other.val_.isEmpty()) {
         if (val_.isEmpty()) {
           val_ = other.val_;
-          bitField0_ = (bitField0_ & ~0x00000001);
+          val_.makeImmutable();
+          bitField0_ |= 0x00000001;
         } else {
           ensureValIsMutable();
           val_.addAll(other.val_);
@@ -436,10 +433,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList val_ = emptyLongList();
     private void ensureValIsMutable() {
-      if (!((bitField0_ & 0x00000001) != 0)) {
-        val_ = mutableCopy(val_);
-        bitField0_ |= 0x00000001;
+      if (!val_.isModifiable()) {
+        val_ = makeMutableCopy(val_);
       }
+      bitField0_ |= 0x00000001;
     }
     /**
      * <code>repeated int64 val = 1 [json_name = "val"];</code>
@@ -447,8 +444,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getValList() {
-      return ((bitField0_ & 0x00000001) != 0) ?
-               java.util.Collections.unmodifiableList(val_) : val_;
+      val_.makeImmutable();
+      return val_;
     }
     /**
      * <code>repeated int64 val = 1 [json_name = "val"];</code>
@@ -476,6 +473,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.setLong(index, value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -488,6 +486,7 @@ private static final long serialVersionUID = 0L;
 
       ensureValIsMutable();
       val_.addLong(value);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }
@@ -501,6 +500,7 @@ private static final long serialVersionUID = 0L;
       ensureValIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, val_);
+      bitField0_ |= 0x00000001;
       onChanged();
       return this;
     }

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TestMsg.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TestMsg.java
@@ -39,6 +39,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TestMsg.class, build.buf.validate.conformance.cases.TestMsg.Builder.class);
   }
 
+  private int bitField0_;
   public static final int CONST_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
   private volatile java.lang.Object const_ = "";
@@ -86,7 +87,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasNested() {
-    return nested_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.TestMsg nested = 2 [json_name = "nested"];</code>
@@ -121,7 +122,7 @@ private static final long serialVersionUID = 0L;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(const_)) {
       com.google.protobuf.GeneratedMessageV3.writeString(output, 1, const_);
     }
-    if (nested_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(2, getNested());
     }
     getUnknownFields().writeTo(output);
@@ -136,7 +137,7 @@ private static final long serialVersionUID = 0L;
     if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(const_)) {
       size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, const_);
     }
-    if (nested_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(2, getNested());
     }
@@ -298,13 +299,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TestMsg.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getNestedFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -352,11 +359,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.nested_ = nestedBuilder_ == null
             ? nested_
             : nestedBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -604,8 +614,10 @@ private static final long serialVersionUID = 0L;
       } else {
         nestedBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000002;
-      onChanged();
+      if (nested_ != null) {
+        bitField0_ |= 0x00000002;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampConst.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampConst.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampConst.class, build.buf.validate.conformance.cases.TimestampConst.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampConst.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampConst result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampExGTELTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampExGTELTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampExGTELTE.class, build.buf.validate.conformance.cases.TimestampExGTELTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampExGTELTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampExGTELTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampExLTGT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampExLTGT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampExLTGT.class, build.buf.validate.conformance.cases.TimestampExLTGT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampExLTGT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampExLTGT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampGT.class, build.buf.validate.conformance.cases.TimestampGT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampGT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampGT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampGTE.class, build.buf.validate.conformance.cases.TimestampGTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampGTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampGTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTELTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTELTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampGTELTE.class, build.buf.validate.conformance.cases.TimestampGTELTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampGTELTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampGTELTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTLT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTLT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampGTLT.class, build.buf.validate.conformance.cases.TimestampGTLT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampGTLT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampGTLT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTNow.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTNow.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampGTNow.class, build.buf.validate.conformance.cases.TimestampGTNow.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampGTNow.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampGTNow result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTNowWithin.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampGTNowWithin.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampGTNowWithin.class, build.buf.validate.conformance.cases.TimestampGTNowWithin.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampGTNowWithin.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampGTNowWithin result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLT.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLT.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampLT.class, build.buf.validate.conformance.cases.TimestampLT.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampLT.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampLT result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLTE.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLTE.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampLTE.class, build.buf.validate.conformance.cases.TimestampLTE.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampLTE.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampLTE result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLTNow.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLTNow.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampLTNow.class, build.buf.validate.conformance.cases.TimestampLTNow.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampLTNow.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampLTNow result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLTNowWithin.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampLTNowWithin.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampLTNowWithin.class, build.buf.validate.conformance.cases.TimestampLTNowWithin.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampLTNowWithin.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampLTNowWithin result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampNone.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampNone.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampNone.class, build.buf.validate.conformance.cases.TimestampNone.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val"];</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampNone.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampNone result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampRequired.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampRequired.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampRequired.class, build.buf.validate.conformance.cases.TimestampRequired.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampRequired.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampRequired result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampWithin.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/TimestampWithin.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.TimestampWithin.class, build.buf.validate.conformance.cases.TimestampWithin.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Timestamp val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Timestamp val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.TimestampWithin.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.TimestampWithin result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WktLevelOne.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WktLevelOne.java
@@ -644,6 +644,7 @@ private static final long serialVersionUID = 0L;
 
     }
 
+    private int bitField0_;
     public static final int THREE_FIELD_NUMBER = 1;
     private build.buf.validate.conformance.cases.WktLevelOne.WktLevelTwo.WktLevelThree three_;
     /**
@@ -652,7 +653,7 @@ private static final long serialVersionUID = 0L;
      */
     @java.lang.Override
     public boolean hasThree() {
-      return three_ != null;
+      return ((bitField0_ & 0x00000001) != 0);
     }
     /**
      * <code>.buf.validate.conformance.cases.WktLevelOne.WktLevelTwo.WktLevelThree three = 1 [json_name = "three", (.buf.validate.field) = { ... }</code>
@@ -684,7 +685,7 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public void writeTo(com.google.protobuf.CodedOutputStream output)
                         throws java.io.IOException {
-      if (three_ != null) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         output.writeMessage(1, getThree());
       }
       getUnknownFields().writeTo(output);
@@ -696,7 +697,7 @@ private static final long serialVersionUID = 0L;
       if (size != -1) return size;
 
       size = 0;
-      if (three_ != null) {
+      if (((bitField0_ & 0x00000001) != 0)) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(1, getThree());
       }
@@ -854,13 +855,19 @@ private static final long serialVersionUID = 0L;
 
       // Construct using build.buf.validate.conformance.cases.WktLevelOne.WktLevelTwo.newBuilder()
       private Builder() {
-
+        maybeForceBuilderInitialization();
       }
 
       private Builder(
           com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
         super(parent);
-
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+          getThreeFieldBuilder();
+        }
       }
       @java.lang.Override
       public Builder clear() {
@@ -904,11 +911,14 @@ private static final long serialVersionUID = 0L;
 
       private void buildPartial0(build.buf.validate.conformance.cases.WktLevelOne.WktLevelTwo result) {
         int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
         if (((from_bitField0_ & 0x00000001) != 0)) {
           result.three_ = threeBuilder_ == null
               ? three_
               : threeBuilder_.build();
+          to_bitField0_ |= 0x00000001;
         }
+        result.bitField0_ |= to_bitField0_;
       }
 
       @java.lang.Override
@@ -1074,8 +1084,10 @@ private static final long serialVersionUID = 0L;
         } else {
           threeBuilder_.mergeFrom(value);
         }
-        bitField0_ |= 0x00000001;
-        onChanged();
+        if (three_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
         return this;
       }
       /**
@@ -1190,6 +1202,7 @@ private static final long serialVersionUID = 0L;
 
   }
 
+  private int bitField0_;
   public static final int TWO_FIELD_NUMBER = 1;
   private build.buf.validate.conformance.cases.WktLevelOne.WktLevelTwo two_;
   /**
@@ -1198,7 +1211,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasTwo() {
-    return two_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.WktLevelOne.WktLevelTwo two = 1 [json_name = "two", (.buf.validate.field) = { ... }</code>
@@ -1230,7 +1243,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (two_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getTwo());
     }
     getUnknownFields().writeTo(output);
@@ -1242,7 +1255,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (two_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getTwo());
     }
@@ -1400,13 +1413,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WktLevelOne.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getTwoFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -1450,11 +1469,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WktLevelOne result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.two_ = twoBuilder_ == null
             ? two_
             : twoBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -1620,8 +1642,10 @@ private static final long serialVersionUID = 0L;
       } else {
         twoBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (two_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperBool.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperBool.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperBool.class, build.buf.validate.conformance.cases.WrapperBool.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.BoolValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.BoolValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperBool.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperBool result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperBytes.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperBytes.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperBytes.class, build.buf.validate.conformance.cases.WrapperBytes.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.BytesValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.BytesValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperBytes.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperBytes result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperDouble.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperDouble.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperDouble.class, build.buf.validate.conformance.cases.WrapperDouble.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.DoubleValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.DoubleValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperDouble.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperDouble result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperFloat.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperFloat.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperFloat.class, build.buf.validate.conformance.cases.WrapperFloat.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.FloatValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.FloatValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperFloat.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperFloat result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperInt32.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperInt32.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperInt32.class, build.buf.validate.conformance.cases.WrapperInt32.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Int32Value val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Int32Value val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperInt32.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperInt32 result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperInt64.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperInt64.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperInt64.class, build.buf.validate.conformance.cases.WrapperInt64.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Int64Value val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Int64Value val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperInt64.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperInt64 result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperNone.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperNone.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperNone.class, build.buf.validate.conformance.cases.WrapperNone.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.Int32Value val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.Int32Value val = 1 [json_name = "val"];</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperNone.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperNone result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperOptionalUuidString.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperOptionalUuidString.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperOptionalUuidString.class, build.buf.validate.conformance.cases.WrapperOptionalUuidString.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.StringValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.StringValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperOptionalUuidString.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperOptionalUuidString result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperRequiredEmptyString.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperRequiredEmptyString.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperRequiredEmptyString.class, build.buf.validate.conformance.cases.WrapperRequiredEmptyString.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.StringValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.StringValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperRequiredEmptyString.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperRequiredEmptyString result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperRequiredFloat.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperRequiredFloat.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperRequiredFloat.class, build.buf.validate.conformance.cases.WrapperRequiredFloat.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.FloatValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.FloatValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperRequiredFloat.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperRequiredFloat result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperRequiredString.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperRequiredString.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperRequiredString.class, build.buf.validate.conformance.cases.WrapperRequiredString.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.StringValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.StringValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperRequiredString.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperRequiredString result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperString.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperString.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperString.class, build.buf.validate.conformance.cases.WrapperString.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.StringValue val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.StringValue val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperString.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperString result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperUInt32.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperUInt32.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperUInt32.class, build.buf.validate.conformance.cases.WrapperUInt32.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.UInt32Value val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.UInt32Value val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperUInt32.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperUInt32 result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperUInt64.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/WrapperUInt64.java
@@ -38,6 +38,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.cases.WrapperUInt64.class, build.buf.validate.conformance.cases.WrapperUInt64.Builder.class);
   }
 
+  private int bitField0_;
   public static final int VAL_FIELD_NUMBER = 1;
   private com.google.protobuf.UInt64Value val_;
   /**
@@ -46,7 +47,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasVal() {
-    return val_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.UInt64Value val = 1 [json_name = "val", (.buf.validate.field) = { ... }</code>
@@ -78,7 +79,7 @@ private static final long serialVersionUID = 0L;
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(1, getVal());
     }
     getUnknownFields().writeTo(output);
@@ -90,7 +91,7 @@ private static final long serialVersionUID = 0L;
     if (size != -1) return size;
 
     size = 0;
-    if (val_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(1, getVal());
     }
@@ -248,13 +249,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.WrapperUInt64.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getValFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -298,11 +305,14 @@ private static final long serialVersionUID = 0L;
 
     private void buildPartial0(build.buf.validate.conformance.cases.WrapperUInt64 result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.val_ = valBuilder_ == null
             ? val_
             : valBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -468,8 +478,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (val_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/custom_constraints/FieldExpressions.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/custom_constraints/FieldExpressions.java
@@ -515,6 +515,7 @@ private static final long serialVersionUID = 0L;
 
   }
 
+  private int bitField0_;
   public static final int A_FIELD_NUMBER = 1;
   private int a_ = 0;
   /**
@@ -552,7 +553,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasC() {
-    return c_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.custom_constraints.FieldExpressions.Nested c = 3 [json_name = "c", (.buf.validate.field) = { ... }</code>
@@ -590,7 +591,7 @@ private static final long serialVersionUID = 0L;
     if (b_ != build.buf.validate.conformance.cases.custom_constraints.Enum.ENUM_UNSPECIFIED.getNumber()) {
       output.writeEnum(2, b_);
     }
-    if (c_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(3, getC());
     }
     getUnknownFields().writeTo(output);
@@ -610,7 +611,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeEnumSize(2, b_);
     }
-    if (c_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(3, getC());
     }
@@ -775,13 +776,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.custom_constraints.FieldExpressions.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getCFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -833,11 +840,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.b_ = b_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000004) != 0)) {
         result.c_ = cBuilder_ == null
             ? c_
             : cBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -1104,8 +1114,10 @@ private static final long serialVersionUID = 0L;
       } else {
         cBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000004;
-      onChanged();
+      if (c_ != null) {
+        bitField0_ |= 0x00000004;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/custom_constraints/MessageExpressions.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/custom_constraints/MessageExpressions.java
@@ -592,6 +592,7 @@ private static final long serialVersionUID = 0L;
 
   }
 
+  private int bitField0_;
   public static final int A_FIELD_NUMBER = 1;
   private int a_ = 0;
   /**
@@ -658,7 +659,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasE() {
-    return e_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.custom_constraints.MessageExpressions.Nested e = 5 [json_name = "e"];</code>
@@ -684,7 +685,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasF() {
-    return f_ != null;
+    return ((bitField0_ & 0x00000002) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.custom_constraints.MessageExpressions.Nested f = 6 [json_name = "f"];</code>
@@ -728,10 +729,10 @@ private static final long serialVersionUID = 0L;
     if (d_ != build.buf.validate.conformance.cases.custom_constraints.Enum.ENUM_UNSPECIFIED.getNumber()) {
       output.writeEnum(4, d_);
     }
-    if (e_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(5, getE());
     }
-    if (f_ != null) {
+    if (((bitField0_ & 0x00000002) != 0)) {
       output.writeMessage(6, getF());
     }
     getUnknownFields().writeTo(output);
@@ -759,11 +760,11 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeEnumSize(4, d_);
     }
-    if (e_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(5, getE());
     }
-    if (f_ != null) {
+    if (((bitField0_ & 0x00000002) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(6, getF());
     }
@@ -948,13 +949,20 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.custom_constraints.MessageExpressions.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getEFieldBuilder();
+        getFFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -1019,16 +1027,20 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000008) != 0)) {
         result.d_ = d_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000010) != 0)) {
         result.e_ = eBuilder_ == null
             ? e_
             : eBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
       if (((from_bitField0_ & 0x00000020) != 0)) {
         result.f_ = fBuilder_ == null
             ? f_
             : fBuilder_.build();
+        to_bitField0_ |= 0x00000002;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -1406,8 +1418,10 @@ private static final long serialVersionUID = 0L;
       } else {
         eBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000010;
-      onChanged();
+      if (e_ != null) {
+        bitField0_ |= 0x00000010;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -1525,8 +1539,10 @@ private static final long serialVersionUID = 0L;
       } else {
         fBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000020;
-      onChanged();
+      if (f_ != null) {
+        bitField0_ |= 0x00000020;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/cases/custom_constraints/NoExpressions.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/cases/custom_constraints/NoExpressions.java
@@ -440,6 +440,7 @@ private static final long serialVersionUID = 0L;
 
   }
 
+  private int bitField0_;
   public static final int A_FIELD_NUMBER = 1;
   private int a_ = 0;
   /**
@@ -477,7 +478,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasC() {
-    return c_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.buf.validate.conformance.cases.custom_constraints.NoExpressions.Nested c = 3 [json_name = "c"];</code>
@@ -515,7 +516,7 @@ private static final long serialVersionUID = 0L;
     if (b_ != build.buf.validate.conformance.cases.custom_constraints.Enum.ENUM_UNSPECIFIED.getNumber()) {
       output.writeEnum(2, b_);
     }
-    if (c_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(3, getC());
     }
     getUnknownFields().writeTo(output);
@@ -535,7 +536,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeEnumSize(2, b_);
     }
-    if (c_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(3, getC());
     }
@@ -704,13 +705,19 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.cases.custom_constraints.NoExpressions.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getCFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -762,11 +769,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.b_ = b_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000004) != 0)) {
         result.c_ = cBuilder_ == null
             ? c_
             : cBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -1033,8 +1043,10 @@ private static final long serialVersionUID = 0L;
       } else {
         cBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000004;
-      onChanged();
+      if (c_ != null) {
+        bitField0_ |= 0x00000004;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/harness/CaseResult.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/harness/CaseResult.java
@@ -43,6 +43,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.harness.CaseResult.class, build.buf.validate.conformance.harness.CaseResult.Builder.class);
   }
 
+  private int bitField0_;
   public static final int NAME_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
   private volatile java.lang.Object name_ = "";
@@ -117,7 +118,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasWanted() {
-    return wanted_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <pre>
@@ -155,7 +156,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasGot() {
-    return got_ != null;
+    return ((bitField0_ & 0x00000002) != 0);
   }
   /**
    * <pre>
@@ -193,7 +194,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasInput() {
-    return input_ != null;
+    return ((bitField0_ & 0x00000004) != 0);
   }
   /**
    * <pre>
@@ -254,13 +255,13 @@ private static final long serialVersionUID = 0L;
     if (success_ != false) {
       output.writeBool(2, success_);
     }
-    if (wanted_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(3, getWanted());
     }
-    if (got_ != null) {
+    if (((bitField0_ & 0x00000002) != 0)) {
       output.writeMessage(4, getGot());
     }
-    if (input_ != null) {
+    if (((bitField0_ & 0x00000004) != 0)) {
       output.writeMessage(5, getInput());
     }
     if (expectedFailure_ != false) {
@@ -282,15 +283,15 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeBoolSize(2, success_);
     }
-    if (wanted_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(3, getWanted());
     }
-    if (got_ != null) {
+    if (((bitField0_ & 0x00000002) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(4, getGot());
     }
-    if (input_ != null) {
+    if (((bitField0_ & 0x00000004) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(5, getInput());
     }
@@ -488,13 +489,21 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.harness.CaseResult.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getWantedFieldBuilder();
+        getGotFieldBuilder();
+        getInputFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -557,24 +566,29 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.success_ = success_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000004) != 0)) {
         result.wanted_ = wantedBuilder_ == null
             ? wanted_
             : wantedBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
       if (((from_bitField0_ & 0x00000008) != 0)) {
         result.got_ = gotBuilder_ == null
             ? got_
             : gotBuilder_.build();
+        to_bitField0_ |= 0x00000002;
       }
       if (((from_bitField0_ & 0x00000010) != 0)) {
         result.input_ = inputBuilder_ == null
             ? input_
             : inputBuilder_.build();
+        to_bitField0_ |= 0x00000004;
       }
       if (((from_bitField0_ & 0x00000020) != 0)) {
         result.expectedFailure_ = expectedFailure_;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -942,8 +956,10 @@ private static final long serialVersionUID = 0L;
       } else {
         wantedBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000004;
-      onChanged();
+      if (wanted_ != null) {
+        bitField0_ |= 0x00000004;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -1097,8 +1113,10 @@ private static final long serialVersionUID = 0L;
       } else {
         gotBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000008;
-      onChanged();
+      if (got_ != null) {
+        bitField0_ |= 0x00000008;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -1252,8 +1270,10 @@ private static final long serialVersionUID = 0L;
       } else {
         inputBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000010;
-      onChanged();
+      if (input_ != null) {
+        bitField0_ |= 0x00000010;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/harness/ResultSet.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/harness/ResultSet.java
@@ -43,6 +43,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.harness.ResultSet.class, build.buf.validate.conformance.harness.ResultSet.Builder.class);
   }
 
+  private int bitField0_;
   public static final int SUCCESSES_FIELD_NUMBER = 1;
   private int successes_ = 0;
   /**
@@ -146,7 +147,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasOptions() {
-    return options_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <pre>
@@ -216,7 +217,7 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < suites_.size(); i++) {
       output.writeMessage(3, suites_.get(i));
     }
-    if (options_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(4, getOptions());
     }
     if (expectedFailures_ != 0) {
@@ -243,7 +244,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(3, suites_.get(i));
     }
-    if (options_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(4, getOptions());
     }
@@ -427,13 +428,20 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.harness.ResultSet.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getSuitesFieldBuilder();
+        getOptionsFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -506,14 +514,17 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.failures_ = failures_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000008) != 0)) {
         result.options_ = optionsBuilder_ == null
             ? options_
             : optionsBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
       if (((from_bitField0_ & 0x00000010) != 0)) {
         result.expectedFailures_ = expectedFailures_;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -1167,8 +1178,10 @@ private static final long serialVersionUID = 0L;
       } else {
         optionsBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000008;
-      onChanged();
+      if (options_ != null) {
+        bitField0_ |= 0x00000008;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/harness/SuiteResults.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/harness/SuiteResults.java
@@ -44,6 +44,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.harness.SuiteResults.class, build.buf.validate.conformance.harness.SuiteResults.Builder.class);
   }
 
+  private int bitField0_;
   public static final int NAME_FIELD_NUMBER = 1;
   @SuppressWarnings("serial")
   private volatile java.lang.Object name_ = "";
@@ -194,7 +195,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasFdset() {
-    return fdset_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <pre>
@@ -267,7 +268,7 @@ private static final long serialVersionUID = 0L;
     for (int i = 0; i < cases_.size(); i++) {
       output.writeMessage(4, cases_.get(i));
     }
-    if (fdset_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(5, getFdset());
     }
     if (expectedFailures_ != 0) {
@@ -297,7 +298,7 @@ private static final long serialVersionUID = 0L;
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(4, cases_.get(i));
     }
-    if (fdset_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(5, getFdset());
     }
@@ -485,13 +486,20 @@ private static final long serialVersionUID = 0L;
 
     // Construct using build.buf.validate.conformance.harness.SuiteResults.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getCasesFieldBuilder();
+        getFdsetFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -568,14 +576,17 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000004) != 0)) {
         result.failures_ = failures_;
       }
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000010) != 0)) {
         result.fdset_ = fdsetBuilder_ == null
             ? fdset_
             : fdsetBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
       if (((from_bitField0_ & 0x00000020) != 0)) {
         result.expectedFailures_ = expectedFailures_;
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -1331,8 +1342,10 @@ private static final long serialVersionUID = 0L;
       } else {
         fdsetBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000010;
-      onChanged();
+      if (fdset_ != null) {
+        bitField0_ |= 0x00000010;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/conformance/src/main/java/build/buf/validate/conformance/harness/TestConformanceRequest.java
+++ b/conformance/src/main/java/build/buf/validate/conformance/harness/TestConformanceRequest.java
@@ -56,6 +56,7 @@ private static final long serialVersionUID = 0L;
             build.buf.validate.conformance.harness.TestConformanceRequest.class, build.buf.validate.conformance.harness.TestConformanceRequest.Builder.class);
   }
 
+  private int bitField0_;
   public static final int FDSET_FIELD_NUMBER = 2;
   private com.google.protobuf.DescriptorProtos.FileDescriptorSet fdset_;
   /**
@@ -64,7 +65,7 @@ private static final long serialVersionUID = 0L;
    */
   @java.lang.Override
   public boolean hasFdset() {
-    return fdset_ != null;
+    return ((bitField0_ & 0x00000001) != 0);
   }
   /**
    * <code>.google.protobuf.FileDescriptorSet fdset = 2 [json_name = "fdset"];</code>
@@ -181,7 +182,7 @@ com.google.protobuf.Any defaultValue) {
   @java.lang.Override
   public void writeTo(com.google.protobuf.CodedOutputStream output)
                       throws java.io.IOException {
-    if (fdset_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       output.writeMessage(2, getFdset());
     }
     com.google.protobuf.GeneratedMessageV3
@@ -199,7 +200,7 @@ com.google.protobuf.Any defaultValue) {
     if (size != -1) return size;
 
     size = 0;
-    if (fdset_ != null) {
+    if (((bitField0_ & 0x00000001) != 0)) {
       size += com.google.protobuf.CodedOutputStream
         .computeMessageSize(2, getFdset());
     }
@@ -401,13 +402,19 @@ com.google.protobuf.Any defaultValue) {
 
     // Construct using build.buf.validate.conformance.harness.TestConformanceRequest.newBuilder()
     private Builder() {
-
+      maybeForceBuilderInitialization();
     }
 
     private Builder(
         com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
       super(parent);
-
+      maybeForceBuilderInitialization();
+    }
+    private void maybeForceBuilderInitialization() {
+      if (com.google.protobuf.GeneratedMessageV3
+              .alwaysUseFieldBuilders) {
+        getFdsetFieldBuilder();
+      }
     }
     @java.lang.Override
     public Builder clear() {
@@ -452,15 +459,18 @@ com.google.protobuf.Any defaultValue) {
 
     private void buildPartial0(build.buf.validate.conformance.harness.TestConformanceRequest result) {
       int from_bitField0_ = bitField0_;
+      int to_bitField0_ = 0;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.fdset_ = fdsetBuilder_ == null
             ? fdset_
             : fdsetBuilder_.build();
+        to_bitField0_ |= 0x00000001;
       }
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.cases_ = internalGetCases();
         result.cases_.makeImmutable();
       }
+      result.bitField0_ |= to_bitField0_;
     }
 
     @java.lang.Override
@@ -643,8 +653,10 @@ com.google.protobuf.Any defaultValue) {
       } else {
         fdsetBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (fdset_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,4 +20,5 @@ protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", versio
 spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = "6.21.0" }
 
 [plugins]
-errorprone-plugin = { id = "net.ltgt.errorprone", version = "3.1.0" }
+errorprone = { id = "net.ltgt.errorprone", version = "3.1.0" }
+maven = { id = "com.vanniktech.maven.publish.base", version = "0.25.3" }

--- a/src/main/java/build/buf/validate/BytesRules.java
+++ b/src/main/java/build/buf/validate/BytesRules.java
@@ -26,8 +26,8 @@ private static final long serialVersionUID = 0L;
     prefix_ = com.google.protobuf.ByteString.EMPTY;
     suffix_ = com.google.protobuf.ByteString.EMPTY;
     contains_ = com.google.protobuf.ByteString.EMPTY;
-    in_ = java.util.Collections.emptyList();
-    notIn_ = java.util.Collections.emptyList();
+    in_ = emptyList(com.google.protobuf.ByteString.class);
+    notIn_ = emptyList(com.google.protobuf.ByteString.class);
   }
 
   @java.lang.Override
@@ -500,7 +500,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 8;
   @SuppressWarnings("serial")
-  private java.util.List<com.google.protobuf.ByteString> in_;
+  private com.google.protobuf.Internal.ProtobufList<com.google.protobuf.ByteString> in_ =
+      emptyList(com.google.protobuf.ByteString.class);
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified
@@ -567,7 +568,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 9;
   @SuppressWarnings("serial")
-  private java.util.List<com.google.protobuf.ByteString> notIn_;
+  private com.google.protobuf.Internal.ProtobufList<com.google.protobuf.ByteString> notIn_ =
+      emptyList(com.google.protobuf.ByteString.class);
   /**
    * <pre>
    *`not_in` requires the field value to be not equal to any of the specified
@@ -1190,8 +1192,8 @@ private static final long serialVersionUID = 0L;
       prefix_ = com.google.protobuf.ByteString.EMPTY;
       suffix_ = com.google.protobuf.ByteString.EMPTY;
       contains_ = com.google.protobuf.ByteString.EMPTY;
-      in_ = java.util.Collections.emptyList();
-      notIn_ = java.util.Collections.emptyList();
+      in_ = emptyList(com.google.protobuf.ByteString.class);
+      notIn_ = emptyList(com.google.protobuf.ByteString.class);
       wellKnownCase_ = 0;
       wellKnown_ = null;
       return this;
@@ -1220,24 +1222,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.BytesRules buildPartial() {
       build.buf.validate.BytesRules result = new build.buf.validate.BytesRules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.BytesRules result) {
-      if (((bitField0_ & 0x00000100) != 0)) {
-        in_ = java.util.Collections.unmodifiableList(in_);
-        bitField0_ = (bitField0_ & ~0x00000100);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000200) != 0)) {
-        notIn_ = java.util.Collections.unmodifiableList(notIn_);
-        bitField0_ = (bitField0_ & ~0x00000200);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.BytesRules result) {
@@ -1274,6 +1262,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000080) != 0)) {
         result.contains_ = contains_;
         to_bitField0_ |= 0x00000080;
+      }
+      if (((from_bitField0_ & 0x00000100) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000200) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -1356,7 +1352,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000100);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000100;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1366,7 +1363,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000200);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000200;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -2320,12 +2318,12 @@ private static final long serialVersionUID = 0L;
       return this;
     }
 
-    private java.util.List<com.google.protobuf.ByteString> in_ = java.util.Collections.emptyList();
+    private com.google.protobuf.Internal.ProtobufList<com.google.protobuf.ByteString> in_ = emptyList(com.google.protobuf.ByteString.class);
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000100) != 0)) {
-        in_ = new java.util.ArrayList<com.google.protobuf.ByteString>(in_);
-        bitField0_ |= 0x00000100;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000100;
     }
     /**
      * <pre>
@@ -2346,8 +2344,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<com.google.protobuf.ByteString>
         getInList() {
-      return ((bitField0_ & 0x00000100) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -2414,6 +2412,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureInIsMutable();
       in_.set(index, value);
+      bitField0_ |= 0x00000100;
       onChanged();
       return this;
     }
@@ -2439,6 +2438,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureInIsMutable();
       in_.add(value);
+      bitField0_ |= 0x00000100;
       onChanged();
       return this;
     }
@@ -2465,6 +2465,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000100;
       onChanged();
       return this;
     }
@@ -2486,18 +2487,18 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearIn() {
-      in_ = java.util.Collections.emptyList();
+      in_ = emptyList(com.google.protobuf.ByteString.class);
       bitField0_ = (bitField0_ & ~0x00000100);
       onChanged();
       return this;
     }
 
-    private java.util.List<com.google.protobuf.ByteString> notIn_ = java.util.Collections.emptyList();
+    private com.google.protobuf.Internal.ProtobufList<com.google.protobuf.ByteString> notIn_ = emptyList(com.google.protobuf.ByteString.class);
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000200) != 0)) {
-        notIn_ = new java.util.ArrayList<com.google.protobuf.ByteString>(notIn_);
-        bitField0_ |= 0x00000200;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000200;
     }
     /**
      * <pre>
@@ -2519,8 +2520,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<com.google.protobuf.ByteString>
         getNotInList() {
-      return ((bitField0_ & 0x00000200) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -2590,6 +2591,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureNotInIsMutable();
       notIn_.set(index, value);
+      bitField0_ |= 0x00000200;
       onChanged();
       return this;
     }
@@ -2616,6 +2618,7 @@ private static final long serialVersionUID = 0L;
       if (value == null) { throw new NullPointerException(); }
       ensureNotInIsMutable();
       notIn_.add(value);
+      bitField0_ |= 0x00000200;
       onChanged();
       return this;
     }
@@ -2643,6 +2646,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000200;
       onChanged();
       return this;
     }
@@ -2665,7 +2669,7 @@ private static final long serialVersionUID = 0L;
      * @return This builder for chaining.
      */
     public Builder clearNotIn() {
-      notIn_ = java.util.Collections.emptyList();
+      notIn_ = emptyList(com.google.protobuf.ByteString.class);
       bitField0_ = (bitField0_ & ~0x00000200);
       onChanged();
       return this;

--- a/src/main/java/build/buf/validate/DoubleRules.java
+++ b/src/main/java/build/buf/validate/DoubleRules.java
@@ -395,7 +395,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.DoubleList in_;
+  private com.google.protobuf.Internal.DoubleList in_ =
+      emptyDoubleList();
   /**
    * <pre>
    * `in` requires the field value to be equal to one of the specified values.
@@ -463,7 +464,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.DoubleList notIn_;
+  private com.google.protobuf.Internal.DoubleList notIn_ =
+      emptyDoubleList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -937,24 +939,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.DoubleRules buildPartial() {
       build.buf.validate.DoubleRules result = new build.buf.validate.DoubleRules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.DoubleRules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.DoubleRules result) {
@@ -963,6 +951,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       if (((from_bitField0_ & 0x00000080) != 0)) {
         result.finite_ = finite_;
@@ -1027,7 +1023,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1037,7 +1034,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1133,7 +1131,8 @@ private static final long serialVersionUID = 0L;
             case 50: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureInIsMutable(alloc / 8);
               while (input.getBytesUntilLimit() > 0) {
                 in_.addDouble(input.readDouble());
               }
@@ -1149,7 +1148,8 @@ private static final long serialVersionUID = 0L;
             case 58: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureNotInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureNotInIsMutable(alloc / 8);
               while (input.getBytesUntilLimit() > 0) {
                 notIn_.addDouble(input.readDouble());
               }
@@ -1738,10 +1738,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.DoubleList in_ = emptyDoubleList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
+    }
+    private void ensureInIsMutable(int capacity) {
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_, capacity);
+      }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1762,8 +1768,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Double>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1830,6 +1836,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setDouble(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1855,6 +1862,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addDouble(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1881,6 +1889,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1910,10 +1919,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.DoubleList notIn_ = emptyDoubleList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
+    }
+    private void ensureNotInIsMutable(int capacity) {
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_, capacity);
+      }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1934,8 +1949,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Double>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -2002,6 +2017,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setDouble(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2027,6 +2043,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addDouble(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2053,6 +2070,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/DurationRules.java
+++ b/src/main/java/build/buf/validate/DurationRules.java
@@ -1565,8 +1565,10 @@ private static final long serialVersionUID = 0L;
       } else {
         constBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (const_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/src/main/java/build/buf/validate/EnumRules.java
+++ b/src/main/java/build/buf/validate/EnumRules.java
@@ -157,7 +157,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 3;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList in_;
+  private com.google.protobuf.Internal.IntList in_ =
+      emptyIntList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the
@@ -243,7 +244,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 4;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList notIn_;
+  private com.google.protobuf.Internal.IntList notIn_ =
+      emptyIntList();
   /**
    * <pre>
    *`not_in` requires the field value to be not equal to any of the
@@ -629,23 +631,9 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.EnumRules buildPartial() {
       build.buf.validate.EnumRules result = new build.buf.validate.EnumRules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.EnumRules result) {
-      if (((bitField0_ & 0x00000004) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000004);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000008) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000008);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.EnumRules result) {
@@ -658,6 +646,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000002) != 0)) {
         result.definedOnly_ = definedOnly_;
         to_bitField0_ |= 0x00000002;
+      }
+      if (((from_bitField0_ & 0x00000004) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000008) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -715,7 +711,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000004);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000004;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -725,7 +722,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000008);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000008;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1043,10 +1041,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList in_ = emptyIntList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000004) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000004;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000004;
     }
     /**
      * <pre>
@@ -1073,8 +1071,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getInList() {
-      return ((bitField0_ & 0x00000004) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1159,6 +1157,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setInt(index, value);
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -1190,6 +1189,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addInt(value);
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -1222,6 +1222,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000004;
       onChanged();
       return this;
     }
@@ -1257,10 +1258,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList notIn_ = emptyIntList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000008) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000008;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000008;
     }
     /**
      * <pre>
@@ -1287,8 +1288,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getNotInList() {
-      return ((bitField0_ & 0x00000008) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1373,6 +1374,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setInt(index, value);
+      bitField0_ |= 0x00000008;
       onChanged();
       return this;
     }
@@ -1404,6 +1406,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addInt(value);
+      bitField0_ |= 0x00000008;
       onChanged();
       return this;
     }
@@ -1436,6 +1439,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000008;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/Fixed32Rules.java
+++ b/src/main/java/build/buf/validate/Fixed32Rules.java
@@ -394,7 +394,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList in_;
+  private com.google.protobuf.Internal.IntList in_ =
+      emptyIntList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -462,7 +463,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList notIn_;
+  private com.google.protobuf.Internal.IntList notIn_ =
+      emptyIntList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -896,24 +898,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.Fixed32Rules buildPartial() {
       build.buf.validate.Fixed32Rules result = new build.buf.validate.Fixed32Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.Fixed32Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.Fixed32Rules result) {
@@ -922,6 +910,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -983,7 +979,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -993,7 +990,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1086,7 +1084,8 @@ private static final long serialVersionUID = 0L;
             case 50: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureInIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 in_.addInt(input.readFixed32());
               }
@@ -1102,7 +1101,8 @@ private static final long serialVersionUID = 0L;
             case 58: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureNotInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureNotInIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 notIn_.addInt(input.readFixed32());
               }
@@ -1686,10 +1686,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList in_ = emptyIntList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
+    }
+    private void ensureInIsMutable(int capacity) {
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_, capacity);
+      }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1710,8 +1716,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1778,6 +1784,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setInt(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1803,6 +1810,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addInt(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1829,6 +1837,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1858,10 +1867,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList notIn_ = emptyIntList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
+    }
+    private void ensureNotInIsMutable(int capacity) {
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_, capacity);
+      }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1882,8 +1897,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1950,6 +1965,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setInt(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1975,6 +1991,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addInt(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2001,6 +2018,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/Fixed64Rules.java
+++ b/src/main/java/build/buf/validate/Fixed64Rules.java
@@ -394,7 +394,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList in_;
+  private com.google.protobuf.Internal.LongList in_ =
+      emptyLongList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -462,7 +463,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList notIn_;
+  private com.google.protobuf.Internal.LongList notIn_ =
+      emptyLongList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -901,24 +903,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.Fixed64Rules buildPartial() {
       build.buf.validate.Fixed64Rules result = new build.buf.validate.Fixed64Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.Fixed64Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.Fixed64Rules result) {
@@ -927,6 +915,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -988,7 +984,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -998,7 +995,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1091,7 +1089,8 @@ private static final long serialVersionUID = 0L;
             case 50: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureInIsMutable(alloc / 8);
               while (input.getBytesUntilLimit() > 0) {
                 in_.addLong(input.readFixed64());
               }
@@ -1107,7 +1106,8 @@ private static final long serialVersionUID = 0L;
             case 58: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureNotInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureNotInIsMutable(alloc / 8);
               while (input.getBytesUntilLimit() > 0) {
                 notIn_.addLong(input.readFixed64());
               }
@@ -1691,10 +1691,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList in_ = emptyLongList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
+    }
+    private void ensureInIsMutable(int capacity) {
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_, capacity);
+      }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1715,8 +1721,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1783,6 +1789,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setLong(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1808,6 +1815,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addLong(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1834,6 +1842,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1863,10 +1872,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList notIn_ = emptyLongList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
+    }
+    private void ensureNotInIsMutable(int capacity) {
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_, capacity);
+      }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1887,8 +1902,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1955,6 +1970,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setLong(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1980,6 +1996,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addLong(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2006,6 +2023,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/FloatRules.java
+++ b/src/main/java/build/buf/validate/FloatRules.java
@@ -395,7 +395,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.FloatList in_;
+  private com.google.protobuf.Internal.FloatList in_ =
+      emptyFloatList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -463,7 +464,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.FloatList notIn_;
+  private com.google.protobuf.Internal.FloatList notIn_ =
+      emptyFloatList();
   /**
    * <pre>
    *`in` requires the field value to not be equal to any of the specified
@@ -937,24 +939,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.FloatRules buildPartial() {
       build.buf.validate.FloatRules result = new build.buf.validate.FloatRules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.FloatRules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.FloatRules result) {
@@ -963,6 +951,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       if (((from_bitField0_ & 0x00000080) != 0)) {
         result.finite_ = finite_;
@@ -1027,7 +1023,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1037,7 +1034,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1133,7 +1131,8 @@ private static final long serialVersionUID = 0L;
             case 50: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureInIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 in_.addFloat(input.readFloat());
               }
@@ -1149,7 +1148,8 @@ private static final long serialVersionUID = 0L;
             case 58: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureNotInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureNotInIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 notIn_.addFloat(input.readFloat());
               }
@@ -1738,10 +1738,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.FloatList in_ = emptyFloatList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
+    }
+    private void ensureInIsMutable(int capacity) {
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_, capacity);
+      }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1762,8 +1768,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Float>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1830,6 +1836,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setFloat(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1855,6 +1862,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addFloat(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1881,6 +1889,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1910,10 +1919,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.FloatList notIn_ = emptyFloatList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
+    }
+    private void ensureNotInIsMutable(int capacity) {
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_, capacity);
+      }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1934,8 +1949,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Float>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -2002,6 +2017,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setFloat(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2027,6 +2043,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addFloat(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2053,6 +2070,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/Int32Rules.java
+++ b/src/main/java/build/buf/validate/Int32Rules.java
@@ -395,7 +395,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList in_;
+  private com.google.protobuf.Internal.IntList in_ =
+      emptyIntList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -463,7 +464,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList notIn_;
+  private com.google.protobuf.Internal.IntList notIn_ =
+      emptyIntList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -904,24 +906,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.Int32Rules buildPartial() {
       build.buf.validate.Int32Rules result = new build.buf.validate.Int32Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.Int32Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.Int32Rules result) {
@@ -930,6 +918,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -991,7 +987,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1001,7 +998,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1694,10 +1692,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList in_ = emptyIntList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1718,8 +1716,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1786,6 +1784,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setInt(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1811,6 +1810,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addInt(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1837,6 +1837,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1866,10 +1867,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList notIn_ = emptyIntList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1890,8 +1891,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1958,6 +1959,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setInt(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1983,6 +1985,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addInt(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2009,6 +2012,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/Int64Rules.java
+++ b/src/main/java/build/buf/validate/Int64Rules.java
@@ -395,7 +395,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList in_;
+  private com.google.protobuf.Internal.LongList in_ =
+      emptyLongList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -463,7 +464,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList notIn_;
+  private com.google.protobuf.Internal.LongList notIn_ =
+      emptyLongList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -909,24 +911,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.Int64Rules buildPartial() {
       build.buf.validate.Int64Rules result = new build.buf.validate.Int64Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.Int64Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.Int64Rules result) {
@@ -935,6 +923,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -996,7 +992,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1006,7 +1003,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1699,10 +1697,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList in_ = emptyLongList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1723,8 +1721,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1791,6 +1789,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setLong(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1816,6 +1815,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addLong(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1842,6 +1842,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1871,10 +1872,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList notIn_ = emptyLongList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1895,8 +1896,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1963,6 +1964,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setLong(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1988,6 +1990,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addLong(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2014,6 +2017,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/MapRules.java
+++ b/src/main/java/build/buf/validate/MapRules.java
@@ -1054,8 +1054,10 @@ private static final long serialVersionUID = 0L;
       } else {
         keysBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000004;
-      onChanged();
+      if (keys_ != null) {
+        bitField0_ |= 0x00000004;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -1327,8 +1329,10 @@ private static final long serialVersionUID = 0L;
       } else {
         valuesBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000008;
-      onChanged();
+      if (values_ != null) {
+        bitField0_ |= 0x00000008;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/src/main/java/build/buf/validate/RepeatedRules.java
+++ b/src/main/java/build/buf/validate/RepeatedRules.java
@@ -1123,8 +1123,10 @@ private static final long serialVersionUID = 0L;
       } else {
         itemsBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000008;
-      onChanged();
+      if (items_ != null) {
+        bitField0_ |= 0x00000008;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/src/main/java/build/buf/validate/SFixed32Rules.java
+++ b/src/main/java/build/buf/validate/SFixed32Rules.java
@@ -394,7 +394,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList in_;
+  private com.google.protobuf.Internal.IntList in_ =
+      emptyIntList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -462,7 +463,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList notIn_;
+  private com.google.protobuf.Internal.IntList notIn_ =
+      emptyIntList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -896,24 +898,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.SFixed32Rules buildPartial() {
       build.buf.validate.SFixed32Rules result = new build.buf.validate.SFixed32Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.SFixed32Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.SFixed32Rules result) {
@@ -922,6 +910,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -983,7 +979,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -993,7 +990,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1086,7 +1084,8 @@ private static final long serialVersionUID = 0L;
             case 50: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureInIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 in_.addInt(input.readSFixed32());
               }
@@ -1102,7 +1101,8 @@ private static final long serialVersionUID = 0L;
             case 58: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureNotInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureNotInIsMutable(alloc / 4);
               while (input.getBytesUntilLimit() > 0) {
                 notIn_.addInt(input.readSFixed32());
               }
@@ -1686,10 +1686,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList in_ = emptyIntList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
+    }
+    private void ensureInIsMutable(int capacity) {
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_, capacity);
+      }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1710,8 +1716,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1778,6 +1784,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setInt(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1803,6 +1810,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addInt(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1829,6 +1837,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1858,10 +1867,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList notIn_ = emptyIntList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
+    }
+    private void ensureNotInIsMutable(int capacity) {
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_, capacity);
+      }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1882,8 +1897,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1950,6 +1965,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setInt(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1975,6 +1991,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addInt(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2001,6 +2018,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/SFixed64Rules.java
+++ b/src/main/java/build/buf/validate/SFixed64Rules.java
@@ -394,7 +394,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList in_;
+  private com.google.protobuf.Internal.LongList in_ =
+      emptyLongList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -462,7 +463,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList notIn_;
+  private com.google.protobuf.Internal.LongList notIn_ =
+      emptyLongList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -901,24 +903,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.SFixed64Rules buildPartial() {
       build.buf.validate.SFixed64Rules result = new build.buf.validate.SFixed64Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.SFixed64Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.SFixed64Rules result) {
@@ -927,6 +915,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -988,7 +984,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -998,7 +995,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1091,7 +1089,8 @@ private static final long serialVersionUID = 0L;
             case 50: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureInIsMutable(alloc / 8);
               while (input.getBytesUntilLimit() > 0) {
                 in_.addLong(input.readSFixed64());
               }
@@ -1107,7 +1106,8 @@ private static final long serialVersionUID = 0L;
             case 58: {
               int length = input.readRawVarint32();
               int limit = input.pushLimit(length);
-              ensureNotInIsMutable();
+              int alloc = length > 4096 ? 4096 : length;
+              ensureNotInIsMutable(alloc / 8);
               while (input.getBytesUntilLimit() > 0) {
                 notIn_.addLong(input.readSFixed64());
               }
@@ -1691,10 +1691,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList in_ = emptyLongList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
+    }
+    private void ensureInIsMutable(int capacity) {
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_, capacity);
+      }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1715,8 +1721,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1783,6 +1789,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setLong(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1808,6 +1815,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addLong(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1834,6 +1842,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1863,10 +1872,16 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList notIn_ = emptyLongList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
+    }
+    private void ensureNotInIsMutable(int capacity) {
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_, capacity);
+      }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1887,8 +1902,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1955,6 +1970,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setLong(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1980,6 +1996,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addLong(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2006,6 +2023,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/SInt32Rules.java
+++ b/src/main/java/build/buf/validate/SInt32Rules.java
@@ -394,7 +394,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList in_;
+  private com.google.protobuf.Internal.IntList in_ =
+      emptyIntList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -462,7 +463,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList notIn_;
+  private com.google.protobuf.Internal.IntList notIn_ =
+      emptyIntList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -902,24 +904,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.SInt32Rules buildPartial() {
       build.buf.validate.SInt32Rules result = new build.buf.validate.SInt32Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.SInt32Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.SInt32Rules result) {
@@ -928,6 +916,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -989,7 +985,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -999,7 +996,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1692,10 +1690,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList in_ = emptyIntList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1716,8 +1714,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1784,6 +1782,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setInt(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1809,6 +1808,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addInt(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1835,6 +1835,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1864,10 +1865,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList notIn_ = emptyIntList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1888,8 +1889,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1956,6 +1957,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setInt(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1981,6 +1983,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addInt(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2007,6 +2010,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/SInt64Rules.java
+++ b/src/main/java/build/buf/validate/SInt64Rules.java
@@ -394,7 +394,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList in_;
+  private com.google.protobuf.Internal.LongList in_ =
+      emptyLongList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -462,7 +463,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList notIn_;
+  private com.google.protobuf.Internal.LongList notIn_ =
+      emptyLongList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -907,24 +909,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.SInt64Rules buildPartial() {
       build.buf.validate.SInt64Rules result = new build.buf.validate.SInt64Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.SInt64Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.SInt64Rules result) {
@@ -933,6 +921,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -994,7 +990,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1004,7 +1001,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1697,10 +1695,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList in_ = emptyLongList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1721,8 +1719,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1789,6 +1787,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setLong(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1814,6 +1813,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addLong(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1840,6 +1840,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1869,10 +1870,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList notIn_ = emptyLongList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1893,8 +1894,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1961,6 +1962,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setLong(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1986,6 +1988,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addLong(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2012,6 +2015,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/TimestampRules.java
+++ b/src/main/java/build/buf/validate/TimestampRules.java
@@ -1417,8 +1417,10 @@ private static final long serialVersionUID = 0L;
       } else {
         constBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000001;
-      onChanged();
+      if (const_ != null) {
+        bitField0_ |= 0x00000001;
+        onChanged();
+      }
       return this;
     }
     /**
@@ -2951,8 +2953,10 @@ private static final long serialVersionUID = 0L;
       } else {
         withinBuilder_.mergeFrom(value);
       }
-      bitField0_ |= 0x00000080;
-      onChanged();
+      if (within_ != null) {
+        bitField0_ |= 0x00000080;
+        onChanged();
+      }
       return this;
     }
     /**

--- a/src/main/java/build/buf/validate/UInt32Rules.java
+++ b/src/main/java/build/buf/validate/UInt32Rules.java
@@ -395,7 +395,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList in_;
+  private com.google.protobuf.Internal.IntList in_ =
+      emptyIntList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -463,7 +464,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.IntList notIn_;
+  private com.google.protobuf.Internal.IntList notIn_ =
+      emptyIntList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -904,24 +906,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.UInt32Rules buildPartial() {
       build.buf.validate.UInt32Rules result = new build.buf.validate.UInt32Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.UInt32Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.UInt32Rules result) {
@@ -930,6 +918,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -991,7 +987,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1001,7 +998,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1694,10 +1692,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList in_ = emptyIntList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1718,8 +1716,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1786,6 +1784,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setInt(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1811,6 +1810,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addInt(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1837,6 +1837,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1866,10 +1867,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.IntList notIn_ = emptyIntList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1890,8 +1891,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Integer>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1958,6 +1959,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setInt(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1983,6 +1985,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addInt(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2009,6 +2012,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }

--- a/src/main/java/build/buf/validate/UInt64Rules.java
+++ b/src/main/java/build/buf/validate/UInt64Rules.java
@@ -395,7 +395,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int IN_FIELD_NUMBER = 6;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList in_;
+  private com.google.protobuf.Internal.LongList in_ =
+      emptyLongList();
   /**
    * <pre>
    *`in` requires the field value to be equal to one of the specified values.
@@ -463,7 +464,8 @@ private static final long serialVersionUID = 0L;
 
   public static final int NOT_IN_FIELD_NUMBER = 7;
   @SuppressWarnings("serial")
-  private com.google.protobuf.Internal.LongList notIn_;
+  private com.google.protobuf.Internal.LongList notIn_ =
+      emptyLongList();
   /**
    * <pre>
    *`not_in` requires the field value to not be equal to any of the specified
@@ -909,24 +911,10 @@ private static final long serialVersionUID = 0L;
     @java.lang.Override
     public build.buf.validate.UInt64Rules buildPartial() {
       build.buf.validate.UInt64Rules result = new build.buf.validate.UInt64Rules(this);
-      buildPartialRepeatedFields(result);
       if (bitField0_ != 0) { buildPartial0(result); }
       buildPartialOneofs(result);
       onBuilt();
       return result;
-    }
-
-    private void buildPartialRepeatedFields(build.buf.validate.UInt64Rules result) {
-      if (((bitField0_ & 0x00000020) != 0)) {
-        in_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000020);
-      }
-      result.in_ = in_;
-      if (((bitField0_ & 0x00000040) != 0)) {
-        notIn_.makeImmutable();
-        bitField0_ = (bitField0_ & ~0x00000040);
-      }
-      result.notIn_ = notIn_;
     }
 
     private void buildPartial0(build.buf.validate.UInt64Rules result) {
@@ -935,6 +923,14 @@ private static final long serialVersionUID = 0L;
       if (((from_bitField0_ & 0x00000001) != 0)) {
         result.const_ = const_;
         to_bitField0_ |= 0x00000001;
+      }
+      if (((from_bitField0_ & 0x00000020) != 0)) {
+        in_.makeImmutable();
+        result.in_ = in_;
+      }
+      if (((from_bitField0_ & 0x00000040) != 0)) {
+        notIn_.makeImmutable();
+        result.notIn_ = notIn_;
       }
       result.bitField0_ |= to_bitField0_;
     }
@@ -996,7 +992,8 @@ private static final long serialVersionUID = 0L;
       if (!other.in_.isEmpty()) {
         if (in_.isEmpty()) {
           in_ = other.in_;
-          bitField0_ = (bitField0_ & ~0x00000020);
+          in_.makeImmutable();
+          bitField0_ |= 0x00000020;
         } else {
           ensureInIsMutable();
           in_.addAll(other.in_);
@@ -1006,7 +1003,8 @@ private static final long serialVersionUID = 0L;
       if (!other.notIn_.isEmpty()) {
         if (notIn_.isEmpty()) {
           notIn_ = other.notIn_;
-          bitField0_ = (bitField0_ & ~0x00000040);
+          notIn_.makeImmutable();
+          bitField0_ |= 0x00000040;
         } else {
           ensureNotInIsMutable();
           notIn_.addAll(other.notIn_);
@@ -1699,10 +1697,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList in_ = emptyLongList();
     private void ensureInIsMutable() {
-      if (!((bitField0_ & 0x00000020) != 0)) {
-        in_ = mutableCopy(in_);
-        bitField0_ |= 0x00000020;
+      if (!in_.isModifiable()) {
+        in_ = makeMutableCopy(in_);
       }
+      bitField0_ |= 0x00000020;
     }
     /**
      * <pre>
@@ -1723,8 +1721,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getInList() {
-      return ((bitField0_ & 0x00000020) != 0) ?
-               java.util.Collections.unmodifiableList(in_) : in_;
+      in_.makeImmutable();
+      return in_;
     }
     /**
      * <pre>
@@ -1791,6 +1789,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.setLong(index, value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1816,6 +1815,7 @@ private static final long serialVersionUID = 0L;
 
       ensureInIsMutable();
       in_.addLong(value);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1842,6 +1842,7 @@ private static final long serialVersionUID = 0L;
       ensureInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, in_);
+      bitField0_ |= 0x00000020;
       onChanged();
       return this;
     }
@@ -1871,10 +1872,10 @@ private static final long serialVersionUID = 0L;
 
     private com.google.protobuf.Internal.LongList notIn_ = emptyLongList();
     private void ensureNotInIsMutable() {
-      if (!((bitField0_ & 0x00000040) != 0)) {
-        notIn_ = mutableCopy(notIn_);
-        bitField0_ |= 0x00000040;
+      if (!notIn_.isModifiable()) {
+        notIn_ = makeMutableCopy(notIn_);
       }
+      bitField0_ |= 0x00000040;
     }
     /**
      * <pre>
@@ -1895,8 +1896,8 @@ private static final long serialVersionUID = 0L;
      */
     public java.util.List<java.lang.Long>
         getNotInList() {
-      return ((bitField0_ & 0x00000040) != 0) ?
-               java.util.Collections.unmodifiableList(notIn_) : notIn_;
+      notIn_.makeImmutable();
+      return notIn_;
     }
     /**
      * <pre>
@@ -1963,6 +1964,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.setLong(index, value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -1988,6 +1990,7 @@ private static final long serialVersionUID = 0L;
 
       ensureNotInIsMutable();
       notIn_.addLong(value);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }
@@ -2014,6 +2017,7 @@ private static final long serialVersionUID = 0L;
       ensureNotInIsMutable();
       com.google.protobuf.AbstractMessageLite.Builder.addAll(
           values, notIn_);
+      bitField0_ |= 0x00000040;
       onChanged();
       return this;
     }


### PR DESCRIPTION
Update generated code to match the latest protobuf-java version. Stop running errorprone on generated code. Enable failing on errors with invalid javadocs.