### PR TITLE
Update protovalidate module to v0.4.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # When updating, also update src/test/resources/proto/buf.yaml and re-run 'buf mod update'.
-protovalidate.version = v0.4.3
+protovalidate.version = v0.4.4
 
 # Arguments to the protovalidate-conformance CLI
 protovalidate.conformance.args = --strict_message

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,4 +23,5 @@ spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version = 
 
 [plugins]
 errorprone = { id = "net.ltgt.errorprone", version = "3.1.0" }
+git = { id = "com.palantir.git-version", version = "3.0.0" }
 maven = { id = "com.vanniktech.maven.publish.base", version = "0.25.3" }

--- a/src/main/java/build/buf/validate/AnyRules.java
+++ b/src/main/java/build/buf/validate/AnyRules.java
@@ -52,16 +52,16 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -73,16 +73,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -93,16 +93,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -114,16 +114,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -143,12 +143,12 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -162,12 +162,12 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -180,12 +180,12 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -199,12 +199,12 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -610,16 +610,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -632,16 +632,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -652,16 +652,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -673,16 +673,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -695,16 +695,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -723,16 +723,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -750,16 +750,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -777,16 +777,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -801,16 +801,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field's `type_url` to be equal to one of the
+     * `in` requires the field's `type_url` to be equal to one of the
      *specified values. If it doesn't match any of the specified values, an error
-     *message is generated.
+     * message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  //  The `value` field must have a `type_url` equal to one of the specified values.
+     * ```proto
+     * message MyAny {
+     *   //  The `value` field must have a `type_url` equal to one of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -840,12 +840,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -860,12 +860,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -878,12 +878,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -897,12 +897,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -917,12 +917,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -943,12 +943,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -968,12 +968,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -993,12 +993,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -1015,12 +1015,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
      *
-     *```proto
-     *message MyAny {
-     *  // The field `value` must not have a `type_url` equal to any of the specified values.
+     * ```proto
+     * message MyAny {
+     *   // The field `value` must not have a `type_url` equal to any of the specified values.
      *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 3 [json_name = "notIn"];</code>

--- a/src/main/java/build/buf/validate/AnyRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/AnyRulesOrBuilder.java
@@ -9,16 +9,16 @@ public interface AnyRulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -28,16 +28,16 @@ public interface AnyRulesOrBuilder extends
       getInList();
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -46,16 +46,16 @@ public interface AnyRulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -65,16 +65,16 @@ public interface AnyRulesOrBuilder extends
   java.lang.String getIn(int index);
   /**
    * <pre>
-   *`in` requires the field's `type_url` to be equal to one of the
+   * `in` requires the field's `type_url` to be equal to one of the
    *specified values. If it doesn't match any of the specified values, an error
-   *message is generated.
+   * message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  //  The `value` field must have a `type_url` equal to one of the specified values.
+   * ```proto
+   * message MyAny {
+   *   //  The `value` field must have a `type_url` equal to one of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 2 [json_name = "in"];</code>
@@ -88,12 +88,12 @@ public interface AnyRulesOrBuilder extends
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -105,12 +105,12 @@ public interface AnyRulesOrBuilder extends
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -121,12 +121,12 @@ public interface AnyRulesOrBuilder extends
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>
@@ -138,12 +138,12 @@ public interface AnyRulesOrBuilder extends
    * <pre>
    * requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
    *
-   *```proto
-   *message MyAny {
-   *  // The field `value` must not have a `type_url` equal to any of the specified values.
+   * ```proto
+   * message MyAny {
+   *   // The field `value` must not have a `type_url` equal to any of the specified values.
    *   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 3 [json_name = "notIn"];</code>

--- a/src/main/java/build/buf/validate/BoolRules.java
+++ b/src/main/java/build/buf/validate/BoolRules.java
@@ -48,15 +48,15 @@ private static final long serialVersionUID = 0L;
   private boolean const_ = false;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified boolean value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified boolean value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBool {
-   *  // value must equal true
+   * ```proto
+   * message MyBool {
+   *   // value must equal true
    *   bool value = 1 [(buf.validate.field).bool.const = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -68,15 +68,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified boolean value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified boolean value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBool {
-   *  // value must equal true
+   * ```proto
+   * message MyBool {
+   *   // value must equal true
    *   bool value = 1 [(buf.validate.field).bool.const = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -429,15 +429,15 @@ private static final long serialVersionUID = 0L;
     private boolean const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified boolean value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified boolean value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBool {
-     *  // value must equal true
+     * ```proto
+     * message MyBool {
+     *   // value must equal true
      *   bool value = 1 [(buf.validate.field).bool.const = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -449,15 +449,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified boolean value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified boolean value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBool {
-     *  // value must equal true
+     * ```proto
+     * message MyBool {
+     *   // value must equal true
      *   bool value = 1 [(buf.validate.field).bool.const = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -469,15 +469,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified boolean value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified boolean value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBool {
-     *  // value must equal true
+     * ```proto
+     * message MyBool {
+     *   // value must equal true
      *   bool value = 1 [(buf.validate.field).bool.const = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -493,15 +493,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified boolean value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified boolean value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBool {
-     *  // value must equal true
+     * ```proto
+     * message MyBool {
+     *   // value must equal true
      *   bool value = 1 [(buf.validate.field).bool.const = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/BoolRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/BoolRulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface BoolRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified boolean value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified boolean value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBool {
-   *  // value must equal true
+   * ```proto
+   * message MyBool {
+   *   // value must equal true
    *   bool value = 1 [(buf.validate.field).bool.const = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface BoolRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified boolean value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified boolean value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBool {
-   *  // value must equal true
+   * ```proto
+   * message MyBool {
+   *   // value must equal true
    *   bool value = 1 [(buf.validate.field).bool.const = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/BytesRules.java
+++ b/src/main/java/build/buf/validate/BytesRules.java
@@ -99,15 +99,15 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.ByteString const_ = com.google.protobuf.ByteString.EMPTY;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified bytes
-   *value. If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified bytes
+   * value. If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+   * ```proto
+   * message MyBytes {
+   *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
    *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -119,15 +119,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified bytes
-   *value. If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified bytes
+   * value. If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+   * ```proto
+   * message MyBytes {
+   *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
    *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -142,15 +142,15 @@ private static final long serialVersionUID = 0L;
   private long len_ = 0L;
   /**
    * <pre>
-   *`len` requires the field value to have the specified length in bytes.
-   *If the field value doesn't match, an error message is generated.
+   * `len` requires the field value to have the specified length in bytes.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *      // value length must be 4 bytes.
-   *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be 4 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -162,15 +162,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`len` requires the field value to have the specified length in bytes.
-   *If the field value doesn't match, an error message is generated.
+   * `len` requires the field value to have the specified length in bytes.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *      // value length must be 4 bytes.
-   *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be 4 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -185,16 +185,16 @@ private static final long serialVersionUID = 0L;
   private long minLen_ = 0L;
   /**
    * <pre>
-   *`min_len` requires the field value to have at least the specified minimum
-   *length in bytes.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `min_len` requires the field value to have at least the specified minimum
+   * length in bytes.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value length must be at least 2 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be at least 2 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -206,16 +206,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`min_len` requires the field value to have at least the specified minimum
-   *length in bytes.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `min_len` requires the field value to have at least the specified minimum
+   * length in bytes.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value length must be at least 2 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be at least 2 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -230,16 +230,16 @@ private static final long serialVersionUID = 0L;
   private long maxLen_ = 0L;
   /**
    * <pre>
-   *`max_len` requires the field value to have at most the specified maximum
-   *length in bytes.
-   *If the field value exceeds the requirement, an error message is generated.
+   * `max_len` requires the field value to have at most the specified maximum
+   * length in bytes.
+   * If the field value exceeds the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be at most 6 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be at most 6 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -251,16 +251,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`max_len` requires the field value to have at most the specified maximum
-   *length in bytes.
-   *If the field value exceeds the requirement, an error message is generated.
+   * `max_len` requires the field value to have at most the specified maximum
+   * length in bytes.
+   * If the field value exceeds the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be at most 6 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be at most 6 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -276,18 +276,18 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object pattern_ = "";
   /**
    * <pre>
-   *`pattern` requires the field value to match the specified regular
-   *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-   *The value of the field must be valid UTF-8 or validation will fail with a
-   *runtime error.
-   *If the field value doesn't match the pattern, an error message is generated.
+   * `pattern` requires the field value to match the specified regular
+   * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+   * The value of the field must be valid UTF-8 or validation will fail with a
+   * runtime error.
+   * If the field value doesn't match the pattern, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must match regex pattern "^[a-zA-Z0-9]+$".
-   * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+   *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -299,18 +299,18 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`pattern` requires the field value to match the specified regular
-   *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-   *The value of the field must be valid UTF-8 or validation will fail with a
-   *runtime error.
-   *If the field value doesn't match the pattern, an error message is generated.
+   * `pattern` requires the field value to match the specified regular
+   * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+   * The value of the field must be valid UTF-8 or validation will fail with a
+   * runtime error.
+   * If the field value doesn't match the pattern, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must match regex pattern "^[a-zA-Z0-9]+$".
-   * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+   *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -331,18 +331,18 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`pattern` requires the field value to match the specified regular
-   *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-   *The value of the field must be valid UTF-8 or validation will fail with a
-   *runtime error.
-   *If the field value doesn't match the pattern, an error message is generated.
+   * `pattern` requires the field value to match the specified regular
+   * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+   * The value of the field must be valid UTF-8 or validation will fail with a
+   * runtime error.
+   * If the field value doesn't match the pattern, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must match regex pattern "^[a-zA-Z0-9]+$".
-   * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+   *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -367,16 +367,16 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.ByteString prefix_ = com.google.protobuf.ByteString.EMPTY;
   /**
    * <pre>
-   *`prefix` requires the field value to have the specified bytes at the
-   *beginning of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `prefix` requires the field value to have the specified bytes at the
+   * beginning of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have prefix &#92;x01&#92;x02
-   *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have prefix &#92;x01&#92;x02
+   *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -388,16 +388,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`prefix` requires the field value to have the specified bytes at the
-   *beginning of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `prefix` requires the field value to have the specified bytes at the
+   * beginning of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have prefix &#92;x01&#92;x02
-   *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have prefix &#92;x01&#92;x02
+   *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -412,16 +412,16 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.ByteString suffix_ = com.google.protobuf.ByteString.EMPTY;
   /**
    * <pre>
-   *`suffix` requires the field value to have the specified bytes at the end
-   *of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `suffix` requires the field value to have the specified bytes at the end
+   * of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have suffix &#92;x03&#92;x04
-   * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have suffix &#92;x03&#92;x04
+   *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -433,16 +433,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`suffix` requires the field value to have the specified bytes at the end
-   *of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `suffix` requires the field value to have the specified bytes at the end
+   * of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have suffix &#92;x03&#92;x04
-   * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have suffix &#92;x03&#92;x04
+   *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -457,16 +457,16 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.ByteString contains_ = com.google.protobuf.ByteString.EMPTY;
   /**
    * <pre>
-   *`contains` requires the field value to have the specified bytes anywhere in
-   *the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `contains` requires the field value to have the specified bytes anywhere in
+   * the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value does not contain &#92;x02&#92;x03
-   * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value does not contain &#92;x02&#92;x03
+   *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -478,16 +478,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`contains` requires the field value to have the specified bytes anywhere in
-   *the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `contains` requires the field value to have the specified bytes anywhere in
+   * the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value does not contain &#92;x02&#92;x03
-   * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value does not contain &#92;x02&#92;x03
+   *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -504,16 +504,16 @@ private static final long serialVersionUID = 0L;
       emptyList(com.google.protobuf.ByteString.class);
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified
-   *values. If the field value doesn't match any of the specified values, an
-   *error message is generated.
+   * `in` requires the field value to be equal to one of the specified
+   * values. If the field value doesn't match any of the specified values, an
+   * error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -526,16 +526,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified
-   *values. If the field value doesn't match any of the specified values, an
-   *error message is generated.
+   * `in` requires the field value to be equal to one of the specified
+   * values. If the field value doesn't match any of the specified values, an
+   * error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -546,16 +546,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified
-   *values. If the field value doesn't match any of the specified values, an
-   *error message is generated.
+   * `in` requires the field value to be equal to one of the specified
+   * values. If the field value doesn't match any of the specified values, an
+   * error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -572,17 +572,17 @@ private static final long serialVersionUID = 0L;
       emptyList(com.google.protobuf.ByteString.class);
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the specified
-   *values.
-   *If the field value matches any of the specified values, an error message is
-   *generated.
+   * `not_in` requires the field value to be not equal to any of the specified
+   * values.
+   * If the field value matches any of the specified values, an error message is
+   * generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -595,17 +595,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the specified
-   *values.
-   *If the field value matches any of the specified values, an error message is
-   *generated.
+   * `not_in` requires the field value to be not equal to any of the specified
+   * values.
+   * If the field value matches any of the specified values, an error message is
+   * generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -616,17 +616,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the specified
-   *values.
-   *If the field value matches any of the specified values, an error message is
-   *generated.
+   * `not_in` requires the field value to be not equal to any of the specified
+   * values.
+   * If the field value matches any of the specified values, an error message is
+   * generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -640,15 +640,15 @@ private static final long serialVersionUID = 0L;
   public static final int IP_FIELD_NUMBER = 10;
   /**
    * <pre>
-   *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IP address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IP address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -660,15 +660,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IP address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IP address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -685,15 +685,15 @@ private static final long serialVersionUID = 0L;
   public static final int IPV4_FIELD_NUMBER = 11;
   /**
    * <pre>
-   *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv4 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv4 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -705,15 +705,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv4 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv4 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -730,14 +730,14 @@ private static final long serialVersionUID = 0L;
   public static final int IPV6_FIELD_NUMBER = 12;
   /**
    * <pre>
-   *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv6 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-   *}
-   *```
+   * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv6 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -749,14 +749,14 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv6 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-   *}
-   *```
+   * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv6 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -1516,15 +1516,15 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.ByteString const_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified bytes
-     *value. If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified bytes
+     * value. If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+     * ```proto
+     * message MyBytes {
+     *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
      *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1536,15 +1536,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified bytes
-     *value. If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified bytes
+     * value. If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+     * ```proto
+     * message MyBytes {
+     *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
      *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1556,15 +1556,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified bytes
-     *value. If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified bytes
+     * value. If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+     * ```proto
+     * message MyBytes {
+     *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
      *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1580,15 +1580,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified bytes
-     *value. If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified bytes
+     * value. If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+     * ```proto
+     * message MyBytes {
+     *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
      *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1604,15 +1604,15 @@ private static final long serialVersionUID = 0L;
     private long len_ ;
     /**
      * <pre>
-     *`len` requires the field value to have the specified length in bytes.
-     *If the field value doesn't match, an error message is generated.
+     * `len` requires the field value to have the specified length in bytes.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *      // value length must be 4 bytes.
-     *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be 4 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -1624,15 +1624,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len` requires the field value to have the specified length in bytes.
-     *If the field value doesn't match, an error message is generated.
+     * `len` requires the field value to have the specified length in bytes.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *      // value length must be 4 bytes.
-     *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be 4 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -1644,15 +1644,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len` requires the field value to have the specified length in bytes.
-     *If the field value doesn't match, an error message is generated.
+     * `len` requires the field value to have the specified length in bytes.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *      // value length must be 4 bytes.
-     *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be 4 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -1668,15 +1668,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len` requires the field value to have the specified length in bytes.
-     *If the field value doesn't match, an error message is generated.
+     * `len` requires the field value to have the specified length in bytes.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     *      // value length must be 4 bytes.
-     *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be 4 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -1692,16 +1692,16 @@ private static final long serialVersionUID = 0L;
     private long minLen_ ;
     /**
      * <pre>
-     *`min_len` requires the field value to have at least the specified minimum
-     *length in bytes.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `min_len` requires the field value to have at least the specified minimum
+     * length in bytes.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value length must be at least 2 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be at least 2 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1713,16 +1713,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_len` requires the field value to have at least the specified minimum
-     *length in bytes.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `min_len` requires the field value to have at least the specified minimum
+     * length in bytes.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value length must be at least 2 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be at least 2 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1734,16 +1734,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_len` requires the field value to have at least the specified minimum
-     *length in bytes.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `min_len` requires the field value to have at least the specified minimum
+     * length in bytes.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value length must be at least 2 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be at least 2 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1759,16 +1759,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_len` requires the field value to have at least the specified minimum
-     *length in bytes.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `min_len` requires the field value to have at least the specified minimum
+     * length in bytes.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value length must be at least 2 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value length must be at least 2 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1784,16 +1784,16 @@ private static final long serialVersionUID = 0L;
     private long maxLen_ ;
     /**
      * <pre>
-     *`max_len` requires the field value to have at most the specified maximum
-     *length in bytes.
-     *If the field value exceeds the requirement, an error message is generated.
+     * `max_len` requires the field value to have at most the specified maximum
+     * length in bytes.
+     * If the field value exceeds the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be at most 6 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be at most 6 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1805,16 +1805,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_len` requires the field value to have at most the specified maximum
-     *length in bytes.
-     *If the field value exceeds the requirement, an error message is generated.
+     * `max_len` requires the field value to have at most the specified maximum
+     * length in bytes.
+     * If the field value exceeds the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be at most 6 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be at most 6 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1826,16 +1826,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_len` requires the field value to have at most the specified maximum
-     *length in bytes.
-     *If the field value exceeds the requirement, an error message is generated.
+     * `max_len` requires the field value to have at most the specified maximum
+     * length in bytes.
+     * If the field value exceeds the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be at most 6 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be at most 6 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1851,16 +1851,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_len` requires the field value to have at most the specified maximum
-     *length in bytes.
-     *If the field value exceeds the requirement, an error message is generated.
+     * `max_len` requires the field value to have at most the specified maximum
+     * length in bytes.
+     * If the field value exceeds the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be at most 6 bytes.
-     * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be at most 6 bytes.
+     *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -1876,18 +1876,18 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object pattern_ = "";
     /**
      * <pre>
-     *`pattern` requires the field value to match the specified regular
-     *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-     *The value of the field must be valid UTF-8 or validation will fail with a
-     *runtime error.
-     *If the field value doesn't match the pattern, an error message is generated.
+     * `pattern` requires the field value to match the specified regular
+     * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+     * The value of the field must be valid UTF-8 or validation will fail with a
+     * runtime error.
+     * If the field value doesn't match the pattern, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must match regex pattern "^[a-zA-Z0-9]+$".
-     * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+     *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -1898,18 +1898,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` requires the field value to match the specified regular
-     *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-     *The value of the field must be valid UTF-8 or validation will fail with a
-     *runtime error.
-     *If the field value doesn't match the pattern, an error message is generated.
+     * `pattern` requires the field value to match the specified regular
+     * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+     * The value of the field must be valid UTF-8 or validation will fail with a
+     * runtime error.
+     * If the field value doesn't match the pattern, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must match regex pattern "^[a-zA-Z0-9]+$".
-     * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+     *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -1929,18 +1929,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` requires the field value to match the specified regular
-     *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-     *The value of the field must be valid UTF-8 or validation will fail with a
-     *runtime error.
-     *If the field value doesn't match the pattern, an error message is generated.
+     * `pattern` requires the field value to match the specified regular
+     * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+     * The value of the field must be valid UTF-8 or validation will fail with a
+     * runtime error.
+     * If the field value doesn't match the pattern, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must match regex pattern "^[a-zA-Z0-9]+$".
-     * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+     *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -1961,18 +1961,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` requires the field value to match the specified regular
-     *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-     *The value of the field must be valid UTF-8 or validation will fail with a
-     *runtime error.
-     *If the field value doesn't match the pattern, an error message is generated.
+     * `pattern` requires the field value to match the specified regular
+     * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+     * The value of the field must be valid UTF-8 or validation will fail with a
+     * runtime error.
+     * If the field value doesn't match the pattern, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must match regex pattern "^[a-zA-Z0-9]+$".
-     * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+     *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -1989,18 +1989,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` requires the field value to match the specified regular
-     *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-     *The value of the field must be valid UTF-8 or validation will fail with a
-     *runtime error.
-     *If the field value doesn't match the pattern, an error message is generated.
+     * `pattern` requires the field value to match the specified regular
+     * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+     * The value of the field must be valid UTF-8 or validation will fail with a
+     * runtime error.
+     * If the field value doesn't match the pattern, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must match regex pattern "^[a-zA-Z0-9]+$".
-     * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+     *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -2014,18 +2014,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` requires the field value to match the specified regular
-     *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-     *The value of the field must be valid UTF-8 or validation will fail with a
-     *runtime error.
-     *If the field value doesn't match the pattern, an error message is generated.
+     * `pattern` requires the field value to match the specified regular
+     * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+     * The value of the field must be valid UTF-8 or validation will fail with a
+     * runtime error.
+     * If the field value doesn't match the pattern, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must match regex pattern "^[a-zA-Z0-9]+$".
-     * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+     *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -2045,16 +2045,16 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.ByteString prefix_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <pre>
-     *`prefix` requires the field value to have the specified bytes at the
-     *beginning of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `prefix` requires the field value to have the specified bytes at the
+     * beginning of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have prefix &#92;x01&#92;x02
-     *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have prefix &#92;x01&#92;x02
+     *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -2066,16 +2066,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` requires the field value to have the specified bytes at the
-     *beginning of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `prefix` requires the field value to have the specified bytes at the
+     * beginning of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have prefix &#92;x01&#92;x02
-     *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have prefix &#92;x01&#92;x02
+     *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -2087,16 +2087,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` requires the field value to have the specified bytes at the
-     *beginning of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `prefix` requires the field value to have the specified bytes at the
+     * beginning of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have prefix &#92;x01&#92;x02
-     *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have prefix &#92;x01&#92;x02
+     *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -2112,16 +2112,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` requires the field value to have the specified bytes at the
-     *beginning of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `prefix` requires the field value to have the specified bytes at the
+     * beginning of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have prefix &#92;x01&#92;x02
-     *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have prefix &#92;x01&#92;x02
+     *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -2137,16 +2137,16 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.ByteString suffix_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <pre>
-     *`suffix` requires the field value to have the specified bytes at the end
-     *of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `suffix` requires the field value to have the specified bytes at the end
+     * of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have suffix &#92;x03&#92;x04
-     * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have suffix &#92;x03&#92;x04
+     *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -2158,16 +2158,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` requires the field value to have the specified bytes at the end
-     *of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `suffix` requires the field value to have the specified bytes at the end
+     * of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have suffix &#92;x03&#92;x04
-     * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have suffix &#92;x03&#92;x04
+     *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -2179,16 +2179,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` requires the field value to have the specified bytes at the end
-     *of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `suffix` requires the field value to have the specified bytes at the end
+     * of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have suffix &#92;x03&#92;x04
-     * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have suffix &#92;x03&#92;x04
+     *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -2204,16 +2204,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` requires the field value to have the specified bytes at the end
-     *of the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `suffix` requires the field value to have the specified bytes at the end
+     * of the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value does not have suffix &#92;x03&#92;x04
-     * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value does not have suffix &#92;x03&#92;x04
+     *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -2229,16 +2229,16 @@ private static final long serialVersionUID = 0L;
     private com.google.protobuf.ByteString contains_ = com.google.protobuf.ByteString.EMPTY;
     /**
      * <pre>
-     *`contains` requires the field value to have the specified bytes anywhere in
-     *the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `contains` requires the field value to have the specified bytes anywhere in
+     * the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value does not contain &#92;x02&#92;x03
-     * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value does not contain &#92;x02&#92;x03
+     *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -2250,16 +2250,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` requires the field value to have the specified bytes anywhere in
-     *the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `contains` requires the field value to have the specified bytes anywhere in
+     * the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value does not contain &#92;x02&#92;x03
-     * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value does not contain &#92;x02&#92;x03
+     *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -2271,16 +2271,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` requires the field value to have the specified bytes anywhere in
-     *the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `contains` requires the field value to have the specified bytes anywhere in
+     * the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value does not contain &#92;x02&#92;x03
-     * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value does not contain &#92;x02&#92;x03
+     *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -2296,16 +2296,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` requires the field value to have the specified bytes anywhere in
-     *the string.
-     *If the field value doesn't meet the requirement, an error message is generated.
+     * `contains` requires the field value to have the specified bytes anywhere in
+     * the string.
+     * If the field value doesn't meet the requirement, an error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value does not contain &#92;x02&#92;x03
-     * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value does not contain &#92;x02&#92;x03
+     *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -2327,16 +2327,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified
-     *values. If the field value doesn't match any of the specified values, an
-     *error message is generated.
+     * `in` requires the field value to be equal to one of the specified
+     * values. If the field value doesn't match any of the specified values, an
+     * error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2349,16 +2349,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified
-     *values. If the field value doesn't match any of the specified values, an
-     *error message is generated.
+     * `in` requires the field value to be equal to one of the specified
+     * values. If the field value doesn't match any of the specified values, an
+     * error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2369,16 +2369,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified
-     *values. If the field value doesn't match any of the specified values, an
-     *error message is generated.
+     * `in` requires the field value to be equal to one of the specified
+     * values. If the field value doesn't match any of the specified values, an
+     * error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2390,16 +2390,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified
-     *values. If the field value doesn't match any of the specified values, an
-     *error message is generated.
+     * `in` requires the field value to be equal to one of the specified
+     * values. If the field value doesn't match any of the specified values, an
+     * error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2418,16 +2418,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified
-     *values. If the field value doesn't match any of the specified values, an
-     *error message is generated.
+     * `in` requires the field value to be equal to one of the specified
+     * values. If the field value doesn't match any of the specified values, an
+     * error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2444,16 +2444,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified
-     *values. If the field value doesn't match any of the specified values, an
-     *error message is generated.
+     * `in` requires the field value to be equal to one of the specified
+     * values. If the field value doesn't match any of the specified values, an
+     * error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2471,16 +2471,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified
-     *values. If the field value doesn't match any of the specified values, an
-     *error message is generated.
+     * `in` requires the field value to be equal to one of the specified
+     * values. If the field value doesn't match any of the specified values, an
+     * error message is generated.
      *
-     *```protobuf
-     *message MyBytes {
-     * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```protobuf
+     * message MyBytes {
+     *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2502,17 +2502,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the specified
-     *values.
-     *If the field value matches any of the specified values, an error message is
-     *generated.
+     * `not_in` requires the field value to be not equal to any of the specified
+     * values.
+     * If the field value matches any of the specified values, an error message is
+     * generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2525,17 +2525,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the specified
-     *values.
-     *If the field value matches any of the specified values, an error message is
-     *generated.
+     * `not_in` requires the field value to be not equal to any of the specified
+     * values.
+     * If the field value matches any of the specified values, an error message is
+     * generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2546,17 +2546,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the specified
-     *values.
-     *If the field value matches any of the specified values, an error message is
-     *generated.
+     * `not_in` requires the field value to be not equal to any of the specified
+     * values.
+     * If the field value matches any of the specified values, an error message is
+     * generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2568,17 +2568,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the specified
-     *values.
-     *If the field value matches any of the specified values, an error message is
-     *generated.
+     * `not_in` requires the field value to be not equal to any of the specified
+     * values.
+     * If the field value matches any of the specified values, an error message is
+     * generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2597,17 +2597,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the specified
-     *values.
-     *If the field value matches any of the specified values, an error message is
-     *generated.
+     * `not_in` requires the field value to be not equal to any of the specified
+     * values.
+     * If the field value matches any of the specified values, an error message is
+     * generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2624,17 +2624,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the specified
-     *values.
-     *If the field value matches any of the specified values, an error message is
-     *generated.
+     * `not_in` requires the field value to be not equal to any of the specified
+     * values.
+     * If the field value matches any of the specified values, an error message is
+     * generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2652,17 +2652,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the specified
-     *values.
-     *If the field value matches any of the specified values, an error message is
-     *generated.
+     * `not_in` requires the field value to be not equal to any of the specified
+     * values.
+     * If the field value matches any of the specified values, an error message is
+     * generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-     * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+     *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2677,15 +2677,15 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IP address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IP address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -2696,15 +2696,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IP address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IP address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -2718,15 +2718,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IP address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IP address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -2742,15 +2742,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IP address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IP address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -2767,15 +2767,15 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv4 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv4 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -2786,15 +2786,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv4 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv4 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -2808,15 +2808,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv4 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv4 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -2832,15 +2832,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
+     * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
      *
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv4 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-     *}
-     *```
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv4 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -2857,14 +2857,14 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv6 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-     *}
-     *```
+     * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv6 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -2875,14 +2875,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv6 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-     *}
-     *```
+     * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv6 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -2896,14 +2896,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv6 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-     *}
-     *```
+     * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv6 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -2919,14 +2919,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-     *If the field value doesn't meet this constraint, an error message is generated.
-     *```proto
-     *message MyBytes {
-     * // value must be a valid IPv6 address
-     * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-     *}
-     *```
+     * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+     * If the field value doesn't meet this constraint, an error message is generated.
+     * ```proto
+     * message MyBytes {
+     *   // value must be a valid IPv6 address
+     *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/BytesRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/BytesRulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified bytes
-   *value. If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified bytes
+   * value. If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+   * ```proto
+   * message MyBytes {
+   *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
    *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface BytesRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified bytes
-   *value. If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified bytes
+   * value. If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *  // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
+   * ```proto
+   * message MyBytes {
+   *   // value must be "&#92;x01&#92;x02&#92;x03&#92;x04"
    *   bytes value = 1 [(buf.validate.field).bytes.const = "&#92;x01&#92;x02&#92;x03&#92;x04"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,15 +44,15 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`len` requires the field value to have the specified length in bytes.
-   *If the field value doesn't match, an error message is generated.
+   * `len` requires the field value to have the specified length in bytes.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *      // value length must be 4 bytes.
-   *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be 4 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -61,15 +61,15 @@ public interface BytesRulesOrBuilder extends
   boolean hasLen();
   /**
    * <pre>
-   *`len` requires the field value to have the specified length in bytes.
-   *If the field value doesn't match, an error message is generated.
+   * `len` requires the field value to have the specified length in bytes.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   *      // value length must be 4 bytes.
-   *      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be 4 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 13 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -79,16 +79,16 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`min_len` requires the field value to have at least the specified minimum
-   *length in bytes.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `min_len` requires the field value to have at least the specified minimum
+   * length in bytes.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value length must be at least 2 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be at least 2 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -97,16 +97,16 @@ public interface BytesRulesOrBuilder extends
   boolean hasMinLen();
   /**
    * <pre>
-   *`min_len` requires the field value to have at least the specified minimum
-   *length in bytes.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `min_len` requires the field value to have at least the specified minimum
+   * length in bytes.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value length must be at least 2 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value length must be at least 2 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -116,16 +116,16 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`max_len` requires the field value to have at most the specified maximum
-   *length in bytes.
-   *If the field value exceeds the requirement, an error message is generated.
+   * `max_len` requires the field value to have at most the specified maximum
+   * length in bytes.
+   * If the field value exceeds the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be at most 6 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be at most 6 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -134,16 +134,16 @@ public interface BytesRulesOrBuilder extends
   boolean hasMaxLen();
   /**
    * <pre>
-   *`max_len` requires the field value to have at most the specified maximum
-   *length in bytes.
-   *If the field value exceeds the requirement, an error message is generated.
+   * `max_len` requires the field value to have at most the specified maximum
+   * length in bytes.
+   * If the field value exceeds the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be at most 6 bytes.
-   * optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be at most 6 bytes.
+   *   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -153,18 +153,18 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`pattern` requires the field value to match the specified regular
-   *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-   *The value of the field must be valid UTF-8 or validation will fail with a
-   *runtime error.
-   *If the field value doesn't match the pattern, an error message is generated.
+   * `pattern` requires the field value to match the specified regular
+   * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+   * The value of the field must be valid UTF-8 or validation will fail with a
+   * runtime error.
+   * If the field value doesn't match the pattern, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must match regex pattern "^[a-zA-Z0-9]+$".
-   * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+   *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -173,18 +173,18 @@ public interface BytesRulesOrBuilder extends
   boolean hasPattern();
   /**
    * <pre>
-   *`pattern` requires the field value to match the specified regular
-   *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-   *The value of the field must be valid UTF-8 or validation will fail with a
-   *runtime error.
-   *If the field value doesn't match the pattern, an error message is generated.
+   * `pattern` requires the field value to match the specified regular
+   * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+   * The value of the field must be valid UTF-8 or validation will fail with a
+   * runtime error.
+   * If the field value doesn't match the pattern, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must match regex pattern "^[a-zA-Z0-9]+$".
-   * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+   *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -193,18 +193,18 @@ public interface BytesRulesOrBuilder extends
   java.lang.String getPattern();
   /**
    * <pre>
-   *`pattern` requires the field value to match the specified regular
-   *expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-   *The value of the field must be valid UTF-8 or validation will fail with a
-   *runtime error.
-   *If the field value doesn't match the pattern, an error message is generated.
+   * `pattern` requires the field value to match the specified regular
+   * expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+   * The value of the field must be valid UTF-8 or validation will fail with a
+   * runtime error.
+   * If the field value doesn't match the pattern, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must match regex pattern "^[a-zA-Z0-9]+$".
-   * optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must match regex pattern "^[a-zA-Z0-9]+$".
+   *   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 4 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -215,16 +215,16 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`prefix` requires the field value to have the specified bytes at the
-   *beginning of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `prefix` requires the field value to have the specified bytes at the
+   * beginning of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have prefix &#92;x01&#92;x02
-   *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have prefix &#92;x01&#92;x02
+   *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -233,16 +233,16 @@ public interface BytesRulesOrBuilder extends
   boolean hasPrefix();
   /**
    * <pre>
-   *`prefix` requires the field value to have the specified bytes at the
-   *beginning of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `prefix` requires the field value to have the specified bytes at the
+   * beginning of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have prefix &#92;x01&#92;x02
-   *optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have prefix &#92;x01&#92;x02
+   *   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "&#92;x01&#92;x02"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes prefix = 5 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -252,16 +252,16 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`suffix` requires the field value to have the specified bytes at the end
-   *of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `suffix` requires the field value to have the specified bytes at the end
+   * of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have suffix &#92;x03&#92;x04
-   * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have suffix &#92;x03&#92;x04
+   *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -270,16 +270,16 @@ public interface BytesRulesOrBuilder extends
   boolean hasSuffix();
   /**
    * <pre>
-   *`suffix` requires the field value to have the specified bytes at the end
-   *of the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `suffix` requires the field value to have the specified bytes at the end
+   * of the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value does not have suffix &#92;x03&#92;x04
-   * optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value does not have suffix &#92;x03&#92;x04
+   *   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "&#92;x03&#92;x04"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes suffix = 6 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -289,16 +289,16 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`contains` requires the field value to have the specified bytes anywhere in
-   *the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `contains` requires the field value to have the specified bytes anywhere in
+   * the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value does not contain &#92;x02&#92;x03
-   * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value does not contain &#92;x02&#92;x03
+   *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -307,16 +307,16 @@ public interface BytesRulesOrBuilder extends
   boolean hasContains();
   /**
    * <pre>
-   *`contains` requires the field value to have the specified bytes anywhere in
-   *the string.
-   *If the field value doesn't meet the requirement, an error message is generated.
+   * `contains` requires the field value to have the specified bytes anywhere in
+   * the string.
+   * If the field value doesn't meet the requirement, an error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value does not contain &#92;x02&#92;x03
-   * optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value does not contain &#92;x02&#92;x03
+   *   optional bytes value = 1 [(buf.validate.field).bytes.contains = "&#92;x02&#92;x03"];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bytes contains = 7 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -326,16 +326,16 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified
-   *values. If the field value doesn't match any of the specified values, an
-   *error message is generated.
+   * `in` requires the field value to be equal to one of the specified
+   * values. If the field value doesn't match any of the specified values, an
+   * error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -344,16 +344,16 @@ public interface BytesRulesOrBuilder extends
   java.util.List<com.google.protobuf.ByteString> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified
-   *values. If the field value doesn't match any of the specified values, an
-   *error message is generated.
+   * `in` requires the field value to be equal to one of the specified
+   * values. If the field value doesn't match any of the specified values, an
+   * error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -362,16 +362,16 @@ public interface BytesRulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified
-   *values. If the field value doesn't match any of the specified values, an
-   *error message is generated.
+   * `in` requires the field value to be equal to one of the specified
+   * values. If the field value doesn't match any of the specified values, an
+   * error message is generated.
    *
-   *```protobuf
-   *message MyBytes {
-   * // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```protobuf
+   * message MyBytes {
+   *   // value must in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes in = 8 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -382,17 +382,17 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the specified
-   *values.
-   *If the field value matches any of the specified values, an error message is
-   *generated.
+   * `not_in` requires the field value to be not equal to any of the specified
+   * values.
+   * If the field value matches any of the specified values, an error message is
+   * generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -401,17 +401,17 @@ public interface BytesRulesOrBuilder extends
   java.util.List<com.google.protobuf.ByteString> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the specified
-   *values.
-   *If the field value matches any of the specified values, an error message is
-   *generated.
+   * `not_in` requires the field value to be not equal to any of the specified
+   * values.
+   * If the field value matches any of the specified values, an error message is
+   * generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -420,17 +420,17 @@ public interface BytesRulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the specified
-   *values.
-   *If the field value matches any of the specified values, an error message is
-   *generated.
+   * `not_in` requires the field value to be not equal to any of the specified
+   * values.
+   * If the field value matches any of the specified values, an error message is
+   * generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
-   * optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must not in ["&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"]
+   *   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"&#92;x01&#92;x02", "&#92;x02&#92;x03", "&#92;x03&#92;x04"}];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated bytes not_in = 9 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -441,15 +441,15 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IP address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IP address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -458,15 +458,15 @@ public interface BytesRulesOrBuilder extends
   boolean hasIp();
   /**
    * <pre>
-   *`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IP address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IP address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 10 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -476,15 +476,15 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv4 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv4 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -493,15 +493,15 @@ public interface BytesRulesOrBuilder extends
   boolean hasIpv4();
   /**
    * <pre>
-   *`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
+   * `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
    *
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv4 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-   *}
-   *```
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv4 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 11 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -511,14 +511,14 @@ public interface BytesRulesOrBuilder extends
 
   /**
    * <pre>
-   *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv6 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-   *}
-   *```
+   * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv6 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -527,14 +527,14 @@ public interface BytesRulesOrBuilder extends
   boolean hasIpv6();
   /**
    * <pre>
-   *`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-   *If the field value doesn't meet this constraint, an error message is generated.
-   *```proto
-   *message MyBytes {
-   * // value must be a valid IPv6 address
-   * optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-   *}
-   *```
+   * `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+   * If the field value doesn't meet this constraint, an error message is generated.
+   * ```proto
+   * message MyBytes {
+   *   // value must be a valid IPv6 address
+   *   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 12 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/DoubleRules.java
+++ b/src/main/java/build/buf/validate/DoubleRules.java
@@ -134,15 +134,15 @@ private static final long serialVersionUID = 0L;
   private double const_ = 0D;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyDouble {
+   *   // value must equal 42.0
    *   double value = 1 [(buf.validate.field).double.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,15 +154,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyDouble {
+   *   // value must equal 42.0
    *   double value = 1 [(buf.validate.field).double.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -180,12 +180,12 @@ private static final long serialVersionUID = 0L;
    * value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than 10.0
    *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -201,12 +201,12 @@ private static final long serialVersionUID = 0L;
    * value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than 10.0
    *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -223,16 +223,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified value
+   * `lte` requires the field value to be less than or equal to the specified value
    * (field &lt;= value). If the field value is greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than or equal to 10.0
    *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -244,16 +244,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified value
+   * `lte` requires the field value to be less than or equal to the specified value
    * (field &lt;= value). If the field value is greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than or equal to 10.0
    *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -276,18 +276,18 @@ private static final long serialVersionUID = 0L;
    * range. If the field value doesn't meet the required conditions, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than 5.0 [double.gt]
-   *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than 5.0 [double.gt]
+   *   double value = 1 [(buf.validate.field).double.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -305,18 +305,18 @@ private static final long serialVersionUID = 0L;
    * range. If the field value doesn't meet the required conditions, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than 5.0 [double.gt]
-   *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than 5.0 [double.gt]
+   *   double value = 1 [(buf.validate.field).double.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -339,18 +339,18 @@ private static final long serialVersionUID = 0L;
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than or equal to 5.0 [double.gte]
-   *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than or equal to 5.0 [double.gte]
+   *   double value = 1 [(buf.validate.field).double.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -368,18 +368,18 @@ private static final long serialVersionUID = 0L;
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than or equal to 5.0 [double.gte]
-   *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than or equal to 5.0 [double.gte]
+   *   double value = 1 [(buf.validate.field).double.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -403,12 +403,12 @@ private static final long serialVersionUID = 0L;
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -425,12 +425,12 @@ private static final long serialVersionUID = 0L;
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -445,12 +445,12 @@ private static final long serialVersionUID = 0L;
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -468,16 +468,16 @@ private static final long serialVersionUID = 0L;
       emptyDoubleList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -490,16 +490,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -510,16 +510,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -535,7 +535,7 @@ private static final long serialVersionUID = 0L;
   private boolean finite_ = false;
   /**
    * <pre>
-   *`finite` requires the field value to be finite. If the field value is
+   * `finite` requires the field value to be finite. If the field value is
    * infinite or NaN, an error message is generated.
    * </pre>
    *
@@ -1211,15 +1211,15 @@ private static final long serialVersionUID = 0L;
     private double const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyDouble {
+     *   // value must equal 42.0
      *   double value = 1 [(buf.validate.field).double.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1231,15 +1231,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyDouble {
+     *   // value must equal 42.0
      *   double value = 1 [(buf.validate.field).double.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1251,15 +1251,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyDouble {
+     *   // value must equal 42.0
      *   double value = 1 [(buf.validate.field).double.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1275,15 +1275,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyDouble {
+     *   // value must equal 42.0
      *   double value = 1 [(buf.validate.field).double.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1302,12 +1302,12 @@ private static final long serialVersionUID = 0L;
      * value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than 10.0
      *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1322,12 +1322,12 @@ private static final long serialVersionUID = 0L;
      * value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than 10.0
      *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1345,12 +1345,12 @@ private static final long serialVersionUID = 0L;
      * value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than 10.0
      *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1370,12 +1370,12 @@ private static final long serialVersionUID = 0L;
      * value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than 10.0
      *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1392,16 +1392,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified value
+     * `lte` requires the field value to be less than or equal to the specified value
      * (field &lt;= value). If the field value is greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than or equal to 10.0
      *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1412,16 +1412,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified value
+     * `lte` requires the field value to be less than or equal to the specified value
      * (field &lt;= value). If the field value is greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than or equal to 10.0
      *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1435,16 +1435,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified value
+     * `lte` requires the field value to be less than or equal to the specified value
      * (field &lt;= value). If the field value is greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than or equal to 10.0
      *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1460,16 +1460,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified value
+     * `lte` requires the field value to be less than or equal to the specified value
      * (field &lt;= value). If the field value is greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyDouble {
+     *   // value must be less than or equal to 10.0
      *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1492,18 +1492,18 @@ private static final long serialVersionUID = 0L;
      * range. If the field value doesn't meet the required conditions, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than 5.0 [double.gt]
-     *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than 5.0 [double.gt]
+     *   double value = 1 [(buf.validate.field).double.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1520,18 +1520,18 @@ private static final long serialVersionUID = 0L;
      * range. If the field value doesn't meet the required conditions, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than 5.0 [double.gt]
-     *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than 5.0 [double.gt]
+     *   double value = 1 [(buf.validate.field).double.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1551,18 +1551,18 @@ private static final long serialVersionUID = 0L;
      * range. If the field value doesn't meet the required conditions, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than 5.0 [double.gt]
-     *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than 5.0 [double.gt]
+     *   double value = 1 [(buf.validate.field).double.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1584,18 +1584,18 @@ private static final long serialVersionUID = 0L;
      * range. If the field value doesn't meet the required conditions, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than 5.0 [double.gt]
-     *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than 5.0 [double.gt]
+     *   double value = 1 [(buf.validate.field).double.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1618,18 +1618,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than or equal to 5.0 [double.gte]
-     *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than or equal to 5.0 [double.gte]
+     *   double value = 1 [(buf.validate.field).double.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1646,18 +1646,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than or equal to 5.0 [double.gte]
-     *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than or equal to 5.0 [double.gte]
+     *   double value = 1 [(buf.validate.field).double.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1677,18 +1677,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than or equal to 5.0 [double.gte]
-     *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than or equal to 5.0 [double.gte]
+     *   double value = 1 [(buf.validate.field).double.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1710,18 +1710,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be greater than or equal to 5.0 [double.gte]
-     *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+     * ```proto
+     * message MyDouble {
+     *   // value must be greater than or equal to 5.0 [double.gte]
+     *   double value = 1 [(buf.validate.field).double.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-     *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+     *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-     *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+     *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1755,12 +1755,12 @@ private static final long serialVersionUID = 0L;
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1777,12 +1777,12 @@ private static final long serialVersionUID = 0L;
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1797,12 +1797,12 @@ private static final long serialVersionUID = 0L;
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1818,12 +1818,12 @@ private static final long serialVersionUID = 0L;
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1846,12 +1846,12 @@ private static final long serialVersionUID = 0L;
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1872,12 +1872,12 @@ private static final long serialVersionUID = 0L;
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1899,12 +1899,12 @@ private static final long serialVersionUID = 0L;
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1932,16 +1932,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1954,16 +1954,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1974,16 +1974,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1995,16 +1995,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2023,16 +2023,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2049,16 +2049,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2076,16 +2076,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyDouble {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyDouble {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2101,7 +2101,7 @@ private static final long serialVersionUID = 0L;
     private boolean finite_ ;
     /**
      * <pre>
-     *`finite` requires the field value to be finite. If the field value is
+     * `finite` requires the field value to be finite. If the field value is
      * infinite or NaN, an error message is generated.
      * </pre>
      *
@@ -2114,7 +2114,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`finite` requires the field value to be finite. If the field value is
+     * `finite` requires the field value to be finite. If the field value is
      * infinite or NaN, an error message is generated.
      * </pre>
      *
@@ -2131,7 +2131,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`finite` requires the field value to be finite. If the field value is
+     * `finite` requires the field value to be finite. If the field value is
      * infinite or NaN, an error message is generated.
      * </pre>
      *

--- a/src/main/java/build/buf/validate/DoubleRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/DoubleRulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface DoubleRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyDouble {
+   *   // value must equal 42.0
    *   double value = 1 [(buf.validate.field).double.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface DoubleRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyDouble {
+   *   // value must equal 42.0
    *   double value = 1 [(buf.validate.field).double.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional double const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -48,12 +48,12 @@ public interface DoubleRulesOrBuilder extends
    * value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than 10.0
    *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -66,12 +66,12 @@ public interface DoubleRulesOrBuilder extends
    * value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than 10.0
    *   double value = 1 [(buf.validate.field).double.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface DoubleRulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified value
+   * `lte` requires the field value to be less than or equal to the specified value
    * (field &lt;= value). If the field value is greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than or equal to 10.0
    *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface DoubleRulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified value
+   * `lte` requires the field value to be less than or equal to the specified value
    * (field &lt;= value). If the field value is greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyDouble {
+   *   // value must be less than or equal to 10.0
    *   double value = 1 [(buf.validate.field).double.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>double lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -124,18 +124,18 @@ public interface DoubleRulesOrBuilder extends
    * range. If the field value doesn't meet the required conditions, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than 5.0 [double.gt]
-   *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than 5.0 [double.gt]
+   *   double value = 1 [(buf.validate.field).double.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -150,18 +150,18 @@ public interface DoubleRulesOrBuilder extends
    * range. If the field value doesn't meet the required conditions, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than 5.0 [double.gt]
-   *  double value = 1 [(buf.validate.field).double.gt = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than 5.0 [double.gt]
+   *   double value = 1 [(buf.validate.field).double.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -177,18 +177,18 @@ public interface DoubleRulesOrBuilder extends
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than or equal to 5.0 [double.gte]
-   *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than or equal to 5.0 [double.gte]
+   *   double value = 1 [(buf.validate.field).double.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -203,18 +203,18 @@ public interface DoubleRulesOrBuilder extends
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be greater than or equal to 5.0 [double.gte]
-   *  double value = 1 [(buf.validate.field).double.gte = 5.0];
+   * ```proto
+   * message MyDouble {
+   *   // value must be greater than or equal to 5.0 [double.gte]
+   *   double value = 1 [(buf.validate.field).double.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-   *  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+   *   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-   *  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+   *   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>double gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -228,12 +228,12 @@ public interface DoubleRulesOrBuilder extends
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -246,12 +246,12 @@ public interface DoubleRulesOrBuilder extends
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -264,12 +264,12 @@ public interface DoubleRulesOrBuilder extends
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface DoubleRulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface DoubleRulesOrBuilder extends
   java.util.List<java.lang.Double> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface DoubleRulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyDouble {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyDouble {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated double not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -336,7 +336,7 @@ public interface DoubleRulesOrBuilder extends
 
   /**
    * <pre>
-   *`finite` requires the field value to be finite. If the field value is
+   * `finite` requires the field value to be finite. If the field value is
    * infinite or NaN, an error message is generated.
    * </pre>
    *

--- a/src/main/java/build/buf/validate/DurationRules.java
+++ b/src/main/java/build/buf/validate/DurationRules.java
@@ -133,16 +133,16 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Duration const_;
   /**
    * <pre>
-   *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-   *If the field's value deviates from the specified value, an error message
-   *will be generated.
+   * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+   * If the field's value deviates from the specified value, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must equal 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must equal 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,16 +154,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-   *If the field's value deviates from the specified value, an error message
-   *will be generated.
+   * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+   * If the field's value deviates from the specified value, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must equal 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must equal 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -175,16 +175,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-   *If the field's value deviates from the specified value, an error message
-   *will be generated.
+   * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+   * If the field's value deviates from the specified value, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must equal 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must equal 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -197,16 +197,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-   *exclusive. If the field's value is greater than or equal to the specified
-   *value, an error message will be generated.
+   * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+   * exclusive. If the field's value is greater than or equal to the specified
+   * value, an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -218,16 +218,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-   *exclusive. If the field's value is greater than or equal to the specified
-   *value, an error message will be generated.
+   * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+   * exclusive. If the field's value is greater than or equal to the specified
+   * value, an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-   *exclusive. If the field's value is greater than or equal to the specified
-   *value, an error message will be generated.
+   * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+   * exclusive. If the field's value is greater than or equal to the specified
+   * value, an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -267,16 +267,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`lte` indicates that the field must be less than or equal to the specified
-   *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-   *an error message will be generated.
+   * `lte` indicates that the field must be less than or equal to the specified
+   * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than or equal to 10s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than or equal to 10s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -288,16 +288,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` indicates that the field must be less than or equal to the specified
-   *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-   *an error message will be generated.
+   * `lte` indicates that the field must be less than or equal to the specified
+   * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than or equal to 10s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than or equal to 10s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -312,16 +312,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` indicates that the field must be less than or equal to the specified
-   *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-   *an error message will be generated.
+   * `lte` indicates that the field must be less than or equal to the specified
+   * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than or equal to 10s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than or equal to 10s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -343,18 +343,18 @@ private static final long serialVersionUID = 0L;
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // duration must be greater than 5s [duration.gt]
-   *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+   * ```proto
+   * message MyDuration {
+   *   // duration must be greater than 5s [duration.gt]
+   *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
    *
-   *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-   *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+   *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+   *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
    *
-   *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-   *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+   *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -372,18 +372,18 @@ private static final long serialVersionUID = 0L;
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // duration must be greater than 5s [duration.gt]
-   *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+   * ```proto
+   * message MyDuration {
+   *   // duration must be greater than 5s [duration.gt]
+   *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
    *
-   *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-   *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+   *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+   *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
    *
-   *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-   *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+   *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -404,18 +404,18 @@ private static final long serialVersionUID = 0L;
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // duration must be greater than 5s [duration.gt]
-   *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+   * ```proto
+   * message MyDuration {
+   *   // duration must be greater than 5s [duration.gt]
+   *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
    *
-   *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-   *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+   *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+   *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
    *
-   *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-   *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+   *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -437,8 +437,8 @@ private static final long serialVersionUID = 0L;
    * be outside the specified range. If the field value doesn't meet the
    * required conditions, an error message is generated.
    *
-   *```proto
-   *message MyDuration {
+   * ```proto
+   * message MyDuration {
    *  // duration must be greater than or equal to 5s [duration.gte]
    *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
    *
@@ -447,8 +447,8 @@ private static final long serialVersionUID = 0L;
    *
    *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
    *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -466,8 +466,8 @@ private static final long serialVersionUID = 0L;
    * be outside the specified range. If the field value doesn't meet the
    * required conditions, an error message is generated.
    *
-   *```proto
-   *message MyDuration {
+   * ```proto
+   * message MyDuration {
    *  // duration must be greater than or equal to 5s [duration.gte]
    *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
    *
@@ -476,8 +476,8 @@ private static final long serialVersionUID = 0L;
    *
    *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
    *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -498,8 +498,8 @@ private static final long serialVersionUID = 0L;
    * be outside the specified range. If the field value doesn't meet the
    * required conditions, an error message is generated.
    *
-   *```proto
-   *message MyDuration {
+   * ```proto
+   * message MyDuration {
    *  // duration must be greater than or equal to 5s [duration.gte]
    *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
    *
@@ -508,8 +508,8 @@ private static final long serialVersionUID = 0L;
    *
    *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
    *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -527,16 +527,16 @@ private static final long serialVersionUID = 0L;
   private java.util.List<com.google.protobuf.Duration> in_;
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -547,16 +547,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -568,16 +568,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -588,16 +588,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -608,16 +608,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -633,17 +633,17 @@ private static final long serialVersionUID = 0L;
   private java.util.List<com.google.protobuf.Duration> notIn_;
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -654,17 +654,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -676,17 +676,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -697,17 +697,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -718,17 +718,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1439,16 +1439,16 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> constBuilder_;
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1459,16 +1459,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1483,16 +1483,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1512,16 +1512,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1539,16 +1539,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1573,16 +1573,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1599,16 +1599,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1620,16 +1620,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1644,16 +1644,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-     *If the field's value deviates from the specified value, an error message
-     *will be generated.
+     * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+     * If the field's value deviates from the specified value, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must equal 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must equal 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1676,16 +1676,16 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> ltBuilder_;
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1697,16 +1697,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1728,16 +1728,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1757,16 +1757,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1784,16 +1784,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1820,16 +1820,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1852,16 +1852,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1871,16 +1871,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1898,16 +1898,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-     *exclusive. If the field's value is greater than or equal to the specified
-     *value, an error message will be generated.
+     * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+     * exclusive. If the field's value is greater than or equal to the specified
+     * value, an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than 5s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than 5s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1935,16 +1935,16 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Duration, com.google.protobuf.Duration.Builder, com.google.protobuf.DurationOrBuilder> lteBuilder_;
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1956,16 +1956,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1987,16 +1987,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -2016,16 +2016,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -2043,16 +2043,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -2079,16 +2079,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -2111,16 +2111,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -2130,16 +2130,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -2157,16 +2157,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` indicates that the field must be less than or equal to the specified
-     *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-     *an error message will be generated.
+     * `lte` indicates that the field must be less than or equal to the specified
+     * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be less than or equal to 10s
+     * ```proto
+     * message MyDuration {
+     *   // value must be less than or equal to 10s
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -2200,18 +2200,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2229,18 +2229,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2268,18 +2268,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2305,18 +2305,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2340,18 +2340,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2384,18 +2384,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2424,18 +2424,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2451,18 +2451,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2486,18 +2486,18 @@ private static final long serialVersionUID = 0L;
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // duration must be greater than 5s [duration.gt]
-     *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+     * ```proto
+     * message MyDuration {
+     *   // duration must be greater than 5s [duration.gt]
+     *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
      *
-     *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-     *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+     *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+     *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
      *
-     *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-     *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+     *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2531,8 +2531,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2541,8 +2541,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2560,8 +2560,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2570,8 +2570,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2599,8 +2599,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2609,8 +2609,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2636,8 +2636,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2646,8 +2646,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2671,8 +2671,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2681,8 +2681,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2715,8 +2715,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2725,8 +2725,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2755,8 +2755,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2765,8 +2765,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2782,8 +2782,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2792,8 +2792,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2817,8 +2817,8 @@ private static final long serialVersionUID = 0L;
      * be outside the specified range. If the field value doesn't meet the
      * required conditions, an error message is generated.
      *
-     *```proto
-     *message MyDuration {
+     * ```proto
+     * message MyDuration {
      *  // duration must be greater than or equal to 5s [duration.gte]
      *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
      *
@@ -2827,8 +2827,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
      *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2866,16 +2866,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2889,16 +2889,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2912,16 +2912,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2935,16 +2935,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2965,16 +2965,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -2992,16 +2992,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3021,16 +3021,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3051,16 +3051,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3078,16 +3078,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3105,16 +3105,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3133,16 +3133,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3159,16 +3159,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3185,16 +3185,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3205,16 +3205,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3228,16 +3228,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3252,16 +3252,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3272,16 +3272,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3293,16 +3293,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value doesn't correspond to any of the specified values,
-     *an error message will be generated.
+     * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value doesn't correspond to any of the specified values,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -3340,17 +3340,17 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3364,17 +3364,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3388,17 +3388,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3412,17 +3412,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3443,17 +3443,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3471,17 +3471,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3501,17 +3501,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3532,17 +3532,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3560,17 +3560,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3588,17 +3588,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3617,17 +3617,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3644,17 +3644,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3671,17 +3671,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3692,17 +3692,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3716,17 +3716,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3741,17 +3741,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3762,17 +3762,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -3784,17 +3784,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` denotes that the field must not be equal to
-     *any of the specified values of the `google.protobuf.Duration` type.
-     *If the field's value matches any of these values, an error message will be
-     *generated.
+     * `not_in` denotes that the field must not be equal to
+     * any of the specified values of the `google.protobuf.Duration` type.
+     * If the field's value matches any of these values, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyDuration {
-     *  // value must not be in list [1s, 2s, 3s]
+     * ```proto
+     * message MyDuration {
+     *   // value must not be in list [1s, 2s, 3s]
      *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/DurationRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/DurationRulesOrBuilder.java
@@ -9,16 +9,16 @@ public interface DurationRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-   *If the field's value deviates from the specified value, an error message
-   *will be generated.
+   * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+   * If the field's value deviates from the specified value, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must equal 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must equal 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -27,16 +27,16 @@ public interface DurationRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-   *If the field's value deviates from the specified value, an error message
-   *will be generated.
+   * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+   * If the field's value deviates from the specified value, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must equal 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must equal 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -45,16 +45,16 @@ public interface DurationRulesOrBuilder extends
   com.google.protobuf.Duration getConst();
   /**
    * <pre>
-   *`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-   *If the field's value deviates from the specified value, an error message
-   *will be generated.
+   * `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+   * If the field's value deviates from the specified value, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must equal 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must equal 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -63,16 +63,16 @@ public interface DurationRulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-   *exclusive. If the field's value is greater than or equal to the specified
-   *value, an error message will be generated.
+   * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+   * exclusive. If the field's value is greater than or equal to the specified
+   * value, an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface DurationRulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-   *exclusive. If the field's value is greater than or equal to the specified
-   *value, an error message will be generated.
+   * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+   * exclusive. If the field's value is greater than or equal to the specified
+   * value, an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface DurationRulesOrBuilder extends
   com.google.protobuf.Duration getLt();
   /**
    * <pre>
-   *`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-   *exclusive. If the field's value is greater than or equal to the specified
-   *value, an error message will be generated.
+   * `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+   * exclusive. If the field's value is greater than or equal to the specified
+   * value, an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than 5s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than 5s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lt = 3 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -117,16 +117,16 @@ public interface DurationRulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` indicates that the field must be less than or equal to the specified
-   *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-   *an error message will be generated.
+   * `lte` indicates that the field must be less than or equal to the specified
+   * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than or equal to 10s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than or equal to 10s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -135,16 +135,16 @@ public interface DurationRulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` indicates that the field must be less than or equal to the specified
-   *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-   *an error message will be generated.
+   * `lte` indicates that the field must be less than or equal to the specified
+   * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than or equal to 10s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than or equal to 10s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -153,16 +153,16 @@ public interface DurationRulesOrBuilder extends
   com.google.protobuf.Duration getLte();
   /**
    * <pre>
-   *`lte` indicates that the field must be less than or equal to the specified
-   *value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-   *an error message will be generated.
+   * `lte` indicates that the field must be less than or equal to the specified
+   * value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be less than or equal to 10s
+   * ```proto
+   * message MyDuration {
+   *   // value must be less than or equal to 10s
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration lte = 4 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -177,18 +177,18 @@ public interface DurationRulesOrBuilder extends
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // duration must be greater than 5s [duration.gt]
-   *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+   * ```proto
+   * message MyDuration {
+   *   // duration must be greater than 5s [duration.gt]
+   *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
    *
-   *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-   *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+   *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+   *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
    *
-   *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-   *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+   *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -203,18 +203,18 @@ public interface DurationRulesOrBuilder extends
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // duration must be greater than 5s [duration.gt]
-   *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+   * ```proto
+   * message MyDuration {
+   *   // duration must be greater than 5s [duration.gt]
+   *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
    *
-   *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-   *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+   *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+   *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
    *
-   *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-   *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+   *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -229,18 +229,18 @@ public interface DurationRulesOrBuilder extends
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // duration must be greater than 5s [duration.gt]
-   *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+   * ```proto
+   * message MyDuration {
+   *   // duration must be greater than 5s [duration.gt]
+   *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
    *
-   *  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-   *  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+   *   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+   *   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
    *
-   *  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-   *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   *   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+   *   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -255,8 +255,8 @@ public interface DurationRulesOrBuilder extends
    * be outside the specified range. If the field value doesn't meet the
    * required conditions, an error message is generated.
    *
-   *```proto
-   *message MyDuration {
+   * ```proto
+   * message MyDuration {
    *  // duration must be greater than or equal to 5s [duration.gte]
    *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
    *
@@ -265,8 +265,8 @@ public interface DurationRulesOrBuilder extends
    *
    *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
    *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -281,8 +281,8 @@ public interface DurationRulesOrBuilder extends
    * be outside the specified range. If the field value doesn't meet the
    * required conditions, an error message is generated.
    *
-   *```proto
-   *message MyDuration {
+   * ```proto
+   * message MyDuration {
    *  // duration must be greater than or equal to 5s [duration.gte]
    *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
    *
@@ -291,8 +291,8 @@ public interface DurationRulesOrBuilder extends
    *
    *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
    *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -307,8 +307,8 @@ public interface DurationRulesOrBuilder extends
    * be outside the specified range. If the field value doesn't meet the
    * required conditions, an error message is generated.
    *
-   *```proto
-   *message MyDuration {
+   * ```proto
+   * message MyDuration {
    *  // duration must be greater than or equal to 5s [duration.gte]
    *  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
    *
@@ -317,8 +317,8 @@ public interface DurationRulesOrBuilder extends
    *
    *  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
    *  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Duration gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -327,16 +327,16 @@ public interface DurationRulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -345,16 +345,16 @@ public interface DurationRulesOrBuilder extends
       getInList();
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -362,16 +362,16 @@ public interface DurationRulesOrBuilder extends
   com.google.protobuf.Duration getIn(int index);
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -379,16 +379,16 @@ public interface DurationRulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -397,16 +397,16 @@ public interface DurationRulesOrBuilder extends
       getInOrBuilderList();
   /**
    * <pre>
-   *`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value doesn't correspond to any of the specified values,
-   *an error message will be generated.
+   * `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value doesn't correspond to any of the specified values,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration in = 7 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -416,17 +416,17 @@ public interface DurationRulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -435,17 +435,17 @@ public interface DurationRulesOrBuilder extends
       getNotInList();
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -453,17 +453,17 @@ public interface DurationRulesOrBuilder extends
   com.google.protobuf.Duration getNotIn(int index);
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -471,17 +471,17 @@ public interface DurationRulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -490,17 +490,17 @@ public interface DurationRulesOrBuilder extends
       getNotInOrBuilderList();
   /**
    * <pre>
-   *`not_in` denotes that the field must not be equal to
-   *any of the specified values of the `google.protobuf.Duration` type.
-   *If the field's value matches any of these values, an error message will be
-   *generated.
+   * `not_in` denotes that the field must not be equal to
+   * any of the specified values of the `google.protobuf.Duration` type.
+   * If the field's value matches any of these values, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyDuration {
-   *  // value must not be in list [1s, 2s, 3s]
+   * ```proto
+   * message MyDuration {
+   *   // value must not be in list [1s, 2s, 3s]
    *   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .google.protobuf.Duration not_in = 8 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/EnumRules.java
+++ b/src/main/java/build/buf/validate/EnumRules.java
@@ -49,21 +49,21 @@ private static final long serialVersionUID = 0L;
   private int const_ = 0;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified enum value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified enum value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be exactly MY_ENUM_VALUE1.
+   * message MyMessage {
+   *   // The field `value` must be exactly MY_ENUM_VALUE1.
    *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -75,21 +75,21 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified enum value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified enum value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be exactly MY_ENUM_VALUE1.
+   * message MyMessage {
+   *   // The field `value` must be exactly MY_ENUM_VALUE1.
    *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -104,21 +104,21 @@ private static final long serialVersionUID = 0L;
   private boolean definedOnly_ = false;
   /**
    * <pre>
-   *`defined_only` requires the field value to be one of the defined values for
+   * `defined_only` requires the field value to be one of the defined values for
    * this enum, failing on any undefined value.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be a defined value of MyEnum.
+   * message MyMessage {
+   *   // The field `value` must be a defined value of MyEnum.
    *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -130,21 +130,21 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`defined_only` requires the field value to be one of the defined values for
+   * `defined_only` requires the field value to be one of the defined values for
    * this enum, failing on any undefined value.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be a defined value of MyEnum.
+   * message MyMessage {
+   *   // The field `value` must be a defined value of MyEnum.
    *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -161,22 +161,22 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the
+   * `in` requires the field value to be equal to one of the
    *specified enum values. If the field value doesn't match any of the
    *specified values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be equal to one of the specified values.
+   * message MyMessage {
+   *   // The field `value` must be equal to one of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -189,22 +189,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the
+   * `in` requires the field value to be equal to one of the
    *specified enum values. If the field value doesn't match any of the
    *specified values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be equal to one of the specified values.
+   * message MyMessage {
+   *   // The field `value` must be equal to one of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -215,22 +215,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the
+   * `in` requires the field value to be equal to one of the
    *specified enum values. If the field value doesn't match any of the
    *specified values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be equal to one of the specified values.
+   * message MyMessage {
+   *   // The field `value` must be equal to one of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -248,22 +248,22 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the
+   * `not_in` requires the field value to be not equal to any of the
    *specified enum values. If the field value matches one of the specified
-   *values, an error message is generated.
+   * values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must not be equal to any of the specified values.
+   * message MyMessage {
+   *   // The field `value` must not be equal to any of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -276,22 +276,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the
+   * `not_in` requires the field value to be not equal to any of the
    *specified enum values. If the field value matches one of the specified
-   *values, an error message is generated.
+   * values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must not be equal to any of the specified values.
+   * message MyMessage {
+   *   // The field `value` must not be equal to any of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -302,22 +302,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the
+   * `not_in` requires the field value to be not equal to any of the
    *specified enum values. If the field value matches one of the specified
-   *values, an error message is generated.
+   * values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must not be equal to any of the specified values.
+   * message MyMessage {
+   *   // The field `value` must not be equal to any of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -818,21 +818,21 @@ private static final long serialVersionUID = 0L;
     private int const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified enum value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified enum value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be exactly MY_ENUM_VALUE1.
+     * message MyMessage {
+     *   // The field `value` must be exactly MY_ENUM_VALUE1.
      *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -844,21 +844,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified enum value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified enum value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be exactly MY_ENUM_VALUE1.
+     * message MyMessage {
+     *   // The field `value` must be exactly MY_ENUM_VALUE1.
      *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -870,21 +870,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified enum value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified enum value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be exactly MY_ENUM_VALUE1.
+     * message MyMessage {
+     *   // The field `value` must be exactly MY_ENUM_VALUE1.
      *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -900,21 +900,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified enum value.
-     *If the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified enum value.
+     * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be exactly MY_ENUM_VALUE1.
+     * message MyMessage {
+     *   // The field `value` must be exactly MY_ENUM_VALUE1.
      *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -930,21 +930,21 @@ private static final long serialVersionUID = 0L;
     private boolean definedOnly_ ;
     /**
      * <pre>
-     *`defined_only` requires the field value to be one of the defined values for
+     * `defined_only` requires the field value to be one of the defined values for
      * this enum, failing on any undefined value.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be a defined value of MyEnum.
+     * message MyMessage {
+     *   // The field `value` must be a defined value of MyEnum.
      *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -956,21 +956,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`defined_only` requires the field value to be one of the defined values for
+     * `defined_only` requires the field value to be one of the defined values for
      * this enum, failing on any undefined value.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be a defined value of MyEnum.
+     * message MyMessage {
+     *   // The field `value` must be a defined value of MyEnum.
      *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -982,21 +982,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`defined_only` requires the field value to be one of the defined values for
+     * `defined_only` requires the field value to be one of the defined values for
      * this enum, failing on any undefined value.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be a defined value of MyEnum.
+     * message MyMessage {
+     *   // The field `value` must be a defined value of MyEnum.
      *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -1012,21 +1012,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`defined_only` requires the field value to be one of the defined values for
+     * `defined_only` requires the field value to be one of the defined values for
      * this enum, failing on any undefined value.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be a defined value of MyEnum.
+     * message MyMessage {
+     *   // The field `value` must be a defined value of MyEnum.
      *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -1048,22 +1048,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the
+     * `in` requires the field value to be equal to one of the
      *specified enum values. If the field value doesn't match any of the
      *specified values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be equal to one of the specified values.
+     * message MyMessage {
+     *   // The field `value` must be equal to one of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1076,22 +1076,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the
+     * `in` requires the field value to be equal to one of the
      *specified enum values. If the field value doesn't match any of the
      *specified values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be equal to one of the specified values.
+     * message MyMessage {
+     *   // The field `value` must be equal to one of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1102,22 +1102,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the
+     * `in` requires the field value to be equal to one of the
      *specified enum values. If the field value doesn't match any of the
      *specified values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be equal to one of the specified values.
+     * message MyMessage {
+     *   // The field `value` must be equal to one of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1129,22 +1129,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the
+     * `in` requires the field value to be equal to one of the
      *specified enum values. If the field value doesn't match any of the
      *specified values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be equal to one of the specified values.
+     * message MyMessage {
+     *   // The field `value` must be equal to one of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1163,22 +1163,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the
+     * `in` requires the field value to be equal to one of the
      *specified enum values. If the field value doesn't match any of the
      *specified values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be equal to one of the specified values.
+     * message MyMessage {
+     *   // The field `value` must be equal to one of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1195,22 +1195,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the
+     * `in` requires the field value to be equal to one of the
      *specified enum values. If the field value doesn't match any of the
      *specified values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be equal to one of the specified values.
+     * message MyMessage {
+     *   // The field `value` must be equal to one of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1228,22 +1228,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the
+     * `in` requires the field value to be equal to one of the
      *specified enum values. If the field value doesn't match any of the
      *specified values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must be equal to one of the specified values.
+     * message MyMessage {
+     *   // The field `value` must be equal to one of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1265,22 +1265,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the
+     * `not_in` requires the field value to be not equal to any of the
      *specified enum values. If the field value matches one of the specified
-     *values, an error message is generated.
+     * values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must not be equal to any of the specified values.
+     * message MyMessage {
+     *   // The field `value` must not be equal to any of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1293,22 +1293,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the
+     * `not_in` requires the field value to be not equal to any of the
      *specified enum values. If the field value matches one of the specified
-     *values, an error message is generated.
+     * values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must not be equal to any of the specified values.
+     * message MyMessage {
+     *   // The field `value` must not be equal to any of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1319,22 +1319,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the
+     * `not_in` requires the field value to be not equal to any of the
      *specified enum values. If the field value matches one of the specified
-     *values, an error message is generated.
+     * values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must not be equal to any of the specified values.
+     * message MyMessage {
+     *   // The field `value` must not be equal to any of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1346,22 +1346,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the
+     * `not_in` requires the field value to be not equal to any of the
      *specified enum values. If the field value matches one of the specified
-     *values, an error message is generated.
+     * values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must not be equal to any of the specified values.
+     * message MyMessage {
+     *   // The field `value` must not be equal to any of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1380,22 +1380,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the
+     * `not_in` requires the field value to be not equal to any of the
      *specified enum values. If the field value matches one of the specified
-     *values, an error message is generated.
+     * values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must not be equal to any of the specified values.
+     * message MyMessage {
+     *   // The field `value` must not be equal to any of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1412,22 +1412,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the
+     * `not_in` requires the field value to be not equal to any of the
      *specified enum values. If the field value matches one of the specified
-     *values, an error message is generated.
+     * values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must not be equal to any of the specified values.
+     * message MyMessage {
+     *   // The field `value` must not be equal to any of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1445,22 +1445,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to be not equal to any of the
+     * `not_in` requires the field value to be not equal to any of the
      *specified enum values. If the field value matches one of the specified
-     *values, an error message is generated.
+     * values, an error message is generated.
      *
-     *```proto
-     *enum MyEnum {
-     *  MY_ENUM_UNSPECIFIED = 0;
-     *  MY_ENUM_VALUE1 = 1;
-     *  MY_ENUM_VALUE2 = 2;
-     *}
+     * ```proto
+     * enum MyEnum {
+     *   MY_ENUM_UNSPECIFIED = 0;
+     *   MY_ENUM_VALUE1 = 1;
+     *   MY_ENUM_VALUE2 = 2;
+     * }
      *
-     *message MyMessage {
-     *  // The field `value` must not be equal to any of the specified values.
+     * message MyMessage {
+     *   // The field `value` must not be equal to any of the specified values.
      *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/EnumRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/EnumRulesOrBuilder.java
@@ -9,21 +9,21 @@ public interface EnumRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified enum value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified enum value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be exactly MY_ENUM_VALUE1.
+   * message MyMessage {
+   *   // The field `value` must be exactly MY_ENUM_VALUE1.
    *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -32,21 +32,21 @@ public interface EnumRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified enum value.
-   *If the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified enum value.
+   * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be exactly MY_ENUM_VALUE1.
+   * message MyMessage {
+   *   // The field `value` must be exactly MY_ENUM_VALUE1.
    *   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -56,21 +56,21 @@ public interface EnumRulesOrBuilder extends
 
   /**
    * <pre>
-   *`defined_only` requires the field value to be one of the defined values for
+   * `defined_only` requires the field value to be one of the defined values for
    * this enum, failing on any undefined value.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be a defined value of MyEnum.
+   * message MyMessage {
+   *   // The field `value` must be a defined value of MyEnum.
    *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -79,21 +79,21 @@ public interface EnumRulesOrBuilder extends
   boolean hasDefinedOnly();
   /**
    * <pre>
-   *`defined_only` requires the field value to be one of the defined values for
+   * `defined_only` requires the field value to be one of the defined values for
    * this enum, failing on any undefined value.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be a defined value of MyEnum.
+   * message MyMessage {
+   *   // The field `value` must be a defined value of MyEnum.
    *   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool defined_only = 2 [json_name = "definedOnly"];</code>
@@ -103,22 +103,22 @@ public interface EnumRulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the
+   * `in` requires the field value to be equal to one of the
    *specified enum values. If the field value doesn't match any of the
    *specified values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be equal to one of the specified values.
+   * message MyMessage {
+   *   // The field `value` must be equal to one of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -127,22 +127,22 @@ public interface EnumRulesOrBuilder extends
   java.util.List<java.lang.Integer> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the
+   * `in` requires the field value to be equal to one of the
    *specified enum values. If the field value doesn't match any of the
    *specified values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be equal to one of the specified values.
+   * message MyMessage {
+   *   // The field `value` must be equal to one of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -151,22 +151,22 @@ public interface EnumRulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the
+   * `in` requires the field value to be equal to one of the
    *specified enum values. If the field value doesn't match any of the
    *specified values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must be equal to one of the specified values.
+   * message MyMessage {
+   *   // The field `value` must be equal to one of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 3 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -177,22 +177,22 @@ public interface EnumRulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the
+   * `not_in` requires the field value to be not equal to any of the
    *specified enum values. If the field value matches one of the specified
-   *values, an error message is generated.
+   * values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must not be equal to any of the specified values.
+   * message MyMessage {
+   *   // The field `value` must not be equal to any of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -201,22 +201,22 @@ public interface EnumRulesOrBuilder extends
   java.util.List<java.lang.Integer> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the
+   * `not_in` requires the field value to be not equal to any of the
    *specified enum values. If the field value matches one of the specified
-   *values, an error message is generated.
+   * values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must not be equal to any of the specified values.
+   * message MyMessage {
+   *   // The field `value` must not be equal to any of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -225,22 +225,22 @@ public interface EnumRulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to be not equal to any of the
+   * `not_in` requires the field value to be not equal to any of the
    *specified enum values. If the field value matches one of the specified
-   *values, an error message is generated.
+   * values, an error message is generated.
    *
-   *```proto
-   *enum MyEnum {
-   *  MY_ENUM_UNSPECIFIED = 0;
-   *  MY_ENUM_VALUE1 = 1;
-   *  MY_ENUM_VALUE2 = 2;
-   *}
+   * ```proto
+   * enum MyEnum {
+   *   MY_ENUM_UNSPECIFIED = 0;
+   *   MY_ENUM_VALUE1 = 1;
+   *   MY_ENUM_VALUE2 = 2;
+   * }
    *
-   *message MyMessage {
-   *  // The field `value` must not be equal to any of the specified values.
+   * message MyMessage {
+   *   // The field `value` must not be equal to any of the specified values.
    *   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 4 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/FieldConstraints.java
+++ b/src/main/java/build/buf/validate/FieldConstraints.java
@@ -129,20 +129,20 @@ private static final long serialVersionUID = 0L;
   private java.util.List<build.buf.validate.Constraint> cel_;
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -153,20 +153,20 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -178,20 +178,20 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -202,20 +202,20 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -226,20 +226,20 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -254,16 +254,16 @@ private static final long serialVersionUID = 0L;
   private boolean skipped_ = false;
   /**
    * <pre>
-   *`skipped` is an optional boolean attribute that specifies that the
-   *validation rules of this field should not be evaluated. If skipped is set to
-   *true, any validation rules set for the field will be ignored.
+   * `skipped` is an optional boolean attribute that specifies that the
+   * validation rules of this field should not be evaluated. If skipped is set to
+   * true, any validation rules set for the field will be ignored.
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must not be set.
-   *  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must not be set.
+   *   optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool skipped = 24 [json_name = "skipped"];</code>
@@ -278,16 +278,19 @@ private static final long serialVersionUID = 0L;
   private boolean required_ = false;
   /**
    * <pre>
-   *`required` is an optional boolean attribute that specifies that
-   *this field must be set. If required is set to true, the field value must
-   *not be empty; otherwise, an error message will be generated.
+   * `required` is an optional boolean attribute that specifies that
+   * this field must be set. If required is set to true, the field value must
+   * not be empty; otherwise, an error message will be generated.
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be set.
-   *  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
-   *}
-   *```
+   * Note that `required` validates that `repeated` fields are non-empty, that is
+   * setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
+   *
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be set.
+   *   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool required = 25 [json_name = "required"];</code>
@@ -302,16 +305,16 @@ private static final long serialVersionUID = 0L;
   private boolean ignoreEmpty_ = false;
   /**
    * <pre>
-   *`ignore_empty` specifies that the validation rules of this field should be
-   *evaluated only if the field isn't empty. If the field is empty, no validation
-   *rules are applied.
+   * `ignore_empty` specifies that the validation rules of this field should be
+   * evaluated only if the field isn't empty. If the field is empty, no validation
+   * rules are applied.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The field `value` validation rules should be evaluated only if the field isn't empty.
-   *  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The field `value` validation rules should be evaluated only if the field isn't empty.
+   *   repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ignore_empty = 26 [json_name = "ignoreEmpty"];</code>
@@ -2204,20 +2207,20 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2231,20 +2234,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2258,20 +2261,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2285,20 +2288,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2319,20 +2322,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2350,20 +2353,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2383,20 +2386,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2417,20 +2420,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2448,20 +2451,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2479,20 +2482,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2511,20 +2514,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2541,20 +2544,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2571,20 +2574,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2595,20 +2598,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2622,20 +2625,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2650,20 +2653,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2674,20 +2677,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2699,20 +2702,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * `Constraint` is a repeated field used to represent a textual expression
+     * `cel` is a repeated field used to represent a textual expression
      * in the Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be greater than 42.
-     *  optional int32 value = 1 [(buf.validate.field).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this &gt; 42",
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be greater than 42.
+     *   optional int32 value = 1 [(buf.validate.field).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this &gt; 42",
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -2739,16 +2742,16 @@ private static final long serialVersionUID = 0L;
     private boolean skipped_ ;
     /**
      * <pre>
-     *`skipped` is an optional boolean attribute that specifies that the
-     *validation rules of this field should not be evaluated. If skipped is set to
-     *true, any validation rules set for the field will be ignored.
+     * `skipped` is an optional boolean attribute that specifies that the
+     * validation rules of this field should not be evaluated. If skipped is set to
+     * true, any validation rules set for the field will be ignored.
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must not be set.
-     *  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must not be set.
+     *   optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool skipped = 24 [json_name = "skipped"];</code>
@@ -2760,16 +2763,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`skipped` is an optional boolean attribute that specifies that the
-     *validation rules of this field should not be evaluated. If skipped is set to
-     *true, any validation rules set for the field will be ignored.
+     * `skipped` is an optional boolean attribute that specifies that the
+     * validation rules of this field should not be evaluated. If skipped is set to
+     * true, any validation rules set for the field will be ignored.
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must not be set.
-     *  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must not be set.
+     *   optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool skipped = 24 [json_name = "skipped"];</code>
@@ -2785,16 +2788,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`skipped` is an optional boolean attribute that specifies that the
-     *validation rules of this field should not be evaluated. If skipped is set to
-     *true, any validation rules set for the field will be ignored.
+     * `skipped` is an optional boolean attribute that specifies that the
+     * validation rules of this field should not be evaluated. If skipped is set to
+     * true, any validation rules set for the field will be ignored.
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must not be set.
-     *  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must not be set.
+     *   optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool skipped = 24 [json_name = "skipped"];</code>
@@ -2810,16 +2813,19 @@ private static final long serialVersionUID = 0L;
     private boolean required_ ;
     /**
      * <pre>
-     *`required` is an optional boolean attribute that specifies that
-     *this field must be set. If required is set to true, the field value must
-     *not be empty; otherwise, an error message will be generated.
+     * `required` is an optional boolean attribute that specifies that
+     * this field must be set. If required is set to true, the field value must
+     * not be empty; otherwise, an error message will be generated.
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be set.
-     *  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
-     *}
-     *```
+     * Note that `required` validates that `repeated` fields are non-empty, that is
+     * setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
+     *
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be set.
+     *   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool required = 25 [json_name = "required"];</code>
@@ -2831,16 +2837,19 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`required` is an optional boolean attribute that specifies that
-     *this field must be set. If required is set to true, the field value must
-     *not be empty; otherwise, an error message will be generated.
+     * `required` is an optional boolean attribute that specifies that
+     * this field must be set. If required is set to true, the field value must
+     * not be empty; otherwise, an error message will be generated.
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be set.
-     *  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
-     *}
-     *```
+     * Note that `required` validates that `repeated` fields are non-empty, that is
+     * setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
+     *
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be set.
+     *   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool required = 25 [json_name = "required"];</code>
@@ -2856,16 +2865,19 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`required` is an optional boolean attribute that specifies that
-     *this field must be set. If required is set to true, the field value must
-     *not be empty; otherwise, an error message will be generated.
+     * `required` is an optional boolean attribute that specifies that
+     * this field must be set. If required is set to true, the field value must
+     * not be empty; otherwise, an error message will be generated.
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `value` must be set.
-     *  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
-     *}
-     *```
+     * Note that `required` validates that `repeated` fields are non-empty, that is
+     * setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
+     *
+     * ```proto
+     * message MyMessage {
+     *   // The field `value` must be set.
+     *   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool required = 25 [json_name = "required"];</code>
@@ -2881,16 +2893,16 @@ private static final long serialVersionUID = 0L;
     private boolean ignoreEmpty_ ;
     /**
      * <pre>
-     *`ignore_empty` specifies that the validation rules of this field should be
-     *evaluated only if the field isn't empty. If the field is empty, no validation
-     *rules are applied.
+     * `ignore_empty` specifies that the validation rules of this field should be
+     * evaluated only if the field isn't empty. If the field is empty, no validation
+     * rules are applied.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The field `value` validation rules should be evaluated only if the field isn't empty.
-     *  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The field `value` validation rules should be evaluated only if the field isn't empty.
+     *   repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ignore_empty = 26 [json_name = "ignoreEmpty"];</code>
@@ -2902,16 +2914,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ignore_empty` specifies that the validation rules of this field should be
-     *evaluated only if the field isn't empty. If the field is empty, no validation
-     *rules are applied.
+     * `ignore_empty` specifies that the validation rules of this field should be
+     * evaluated only if the field isn't empty. If the field is empty, no validation
+     * rules are applied.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The field `value` validation rules should be evaluated only if the field isn't empty.
-     *  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The field `value` validation rules should be evaluated only if the field isn't empty.
+     *   repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ignore_empty = 26 [json_name = "ignoreEmpty"];</code>
@@ -2927,16 +2939,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ignore_empty` specifies that the validation rules of this field should be
-     *evaluated only if the field isn't empty. If the field is empty, no validation
-     *rules are applied.
+     * `ignore_empty` specifies that the validation rules of this field should be
+     * evaluated only if the field isn't empty. If the field is empty, no validation
+     * rules are applied.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The field `value` validation rules should be evaluated only if the field isn't empty.
-     *  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The field `value` validation rules should be evaluated only if the field isn't empty.
+     *   repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ignore_empty = 26 [json_name = "ignoreEmpty"];</code>

--- a/src/main/java/build/buf/validate/FieldConstraintsOrBuilder.java
+++ b/src/main/java/build/buf/validate/FieldConstraintsOrBuilder.java
@@ -9,20 +9,20 @@ public interface FieldConstraintsOrBuilder extends
 
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -31,20 +31,20 @@ public interface FieldConstraintsOrBuilder extends
       getCelList();
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -52,20 +52,20 @@ public interface FieldConstraintsOrBuilder extends
   build.buf.validate.Constraint getCel(int index);
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -73,20 +73,20 @@ public interface FieldConstraintsOrBuilder extends
   int getCelCount();
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -95,20 +95,20 @@ public interface FieldConstraintsOrBuilder extends
       getCelOrBuilderList();
   /**
    * <pre>
-   * `Constraint` is a repeated field used to represent a textual expression
+   * `cel` is a repeated field used to represent a textual expression
    * in the Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be greater than 42.
-   *  optional int32 value = 1 [(buf.validate.field).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this &gt; 42",
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be greater than 42.
+   *   optional int32 value = 1 [(buf.validate.field).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this &gt; 42",
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 23 [json_name = "cel"];</code>
@@ -118,16 +118,16 @@ public interface FieldConstraintsOrBuilder extends
 
   /**
    * <pre>
-   *`skipped` is an optional boolean attribute that specifies that the
-   *validation rules of this field should not be evaluated. If skipped is set to
-   *true, any validation rules set for the field will be ignored.
+   * `skipped` is an optional boolean attribute that specifies that the
+   * validation rules of this field should not be evaluated. If skipped is set to
+   * true, any validation rules set for the field will be ignored.
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must not be set.
-   *  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must not be set.
+   *   optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool skipped = 24 [json_name = "skipped"];</code>
@@ -137,16 +137,19 @@ public interface FieldConstraintsOrBuilder extends
 
   /**
    * <pre>
-   *`required` is an optional boolean attribute that specifies that
-   *this field must be set. If required is set to true, the field value must
-   *not be empty; otherwise, an error message will be generated.
+   * `required` is an optional boolean attribute that specifies that
+   * this field must be set. If required is set to true, the field value must
+   * not be empty; otherwise, an error message will be generated.
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `value` must be set.
-   *  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
-   *}
-   *```
+   * Note that `required` validates that `repeated` fields are non-empty, that is
+   * setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
+   *
+   * ```proto
+   * message MyMessage {
+   *   // The field `value` must be set.
+   *   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool required = 25 [json_name = "required"];</code>
@@ -156,16 +159,16 @@ public interface FieldConstraintsOrBuilder extends
 
   /**
    * <pre>
-   *`ignore_empty` specifies that the validation rules of this field should be
-   *evaluated only if the field isn't empty. If the field is empty, no validation
-   *rules are applied.
+   * `ignore_empty` specifies that the validation rules of this field should be
+   * evaluated only if the field isn't empty. If the field is empty, no validation
+   * rules are applied.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The field `value` validation rules should be evaluated only if the field isn't empty.
-   *  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The field `value` validation rules should be evaluated only if the field isn't empty.
+   *   repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ignore_empty = 26 [json_name = "ignoreEmpty"];</code>

--- a/src/main/java/build/buf/validate/Fixed32Rules.java
+++ b/src/main/java/build/buf/validate/Fixed32Rules.java
@@ -133,15 +133,15 @@ private static final long serialVersionUID = 0L;
   private int const_ = 0;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value.
+   * `const` requires the field value to exactly match the specified value.
    * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed32 {
+   *   // value must equal 42
    *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -153,15 +153,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value.
+   * `const` requires the field value to exactly match the specified value.
    * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed32 {
+   *   // value must equal 42
    *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -175,16 +175,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -196,16 +196,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -222,16 +222,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than or equal to 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -243,16 +243,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than or equal to 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -269,24 +269,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than 5 [fixed32.gt]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than 5 [fixed32.gt]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -298,24 +298,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than 5 [fixed32.gt]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than 5 [fixed32.gt]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -332,24 +332,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than or equal to 5 [fixed32.gte]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than or equal to 5 [fixed32.gte]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -361,24 +361,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than or equal to 5 [fixed32.gte]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than or equal to 5 [fixed32.gte]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -398,16 +398,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -420,16 +420,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -440,16 +440,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -467,16 +467,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -489,16 +489,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -509,16 +509,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1159,15 +1159,15 @@ private static final long serialVersionUID = 0L;
     private int const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value.
+     * `const` requires the field value to exactly match the specified value.
      * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed32 {
+     *   // value must equal 42
      *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1179,15 +1179,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value.
+     * `const` requires the field value to exactly match the specified value.
      * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed32 {
+     *   // value must equal 42
      *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1199,15 +1199,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value.
+     * `const` requires the field value to exactly match the specified value.
      * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed32 {
+     *   // value must equal 42
      *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1223,15 +1223,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value.
+     * `const` requires the field value to exactly match the specified value.
      * If the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed32 {
+     *   // value must equal 42
      *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1246,16 +1246,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1266,16 +1266,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1289,16 +1289,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1314,16 +1314,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1340,16 +1340,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than or equal to 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1360,16 +1360,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than or equal to 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1383,16 +1383,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than or equal to 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1408,16 +1408,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be less than or equal to 10
      *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1434,24 +1434,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than 5 [fixed32.gt]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than 5 [fixed32.gt]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1462,24 +1462,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than 5 [fixed32.gt]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than 5 [fixed32.gt]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1493,24 +1493,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than 5 [fixed32.gt]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than 5 [fixed32.gt]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1526,24 +1526,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than 5 [fixed32.gt]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than 5 [fixed32.gt]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1560,24 +1560,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than or equal to 5 [fixed32.gte]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than or equal to 5 [fixed32.gte]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1588,24 +1588,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than or equal to 5 [fixed32.gte]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than or equal to 5 [fixed32.gte]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1619,24 +1619,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than or equal to 5 [fixed32.gte]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than or equal to 5 [fixed32.gte]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1652,24 +1652,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be greater than or equal to 5 [fixed32.gte]
-     *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be greater than or equal to 5 [fixed32.gte]
+     *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-     *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+     *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-     *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+     *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1699,16 +1699,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1721,16 +1721,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1741,16 +1741,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1762,16 +1762,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1790,16 +1790,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1816,16 +1816,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1843,16 +1843,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1880,16 +1880,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1902,16 +1902,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1922,16 +1922,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1943,16 +1943,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1971,16 +1971,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1997,16 +1997,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2024,16 +2024,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/Fixed32RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/Fixed32RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface Fixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value.
+   * `const` requires the field value to exactly match the specified value.
    * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed32 {
+   *   // value must equal 42
    *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface Fixed32RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value.
+   * `const` requires the field value to exactly match the specified value.
    * If the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed32 {
+   *   // value must equal 42
    *   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface Fixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface Fixed32RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface Fixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than or equal to 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface Fixed32RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be less than or equal to 10
    *   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface Fixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than 5 [fixed32.gt]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than 5 [fixed32.gt]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface Fixed32RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than 5 [fixed32.gt]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than 5 [fixed32.gt]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface Fixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than or equal to 5 [fixed32.gte]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than or equal to 5 [fixed32.gte]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface Fixed32RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be greater than or equal to 5 [fixed32.gte]
-   *  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be greater than or equal to 5 [fixed32.gte]
+   *   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-   *  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+   *   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-   *  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+   *   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface Fixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface Fixed32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface Fixed32RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface Fixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface Fixed32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface Fixed32RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/Fixed64Rules.java
+++ b/src/main/java/build/buf/validate/Fixed64Rules.java
@@ -133,15 +133,15 @@ private static final long serialVersionUID = 0L;
   private long const_ = 0L;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed64 {
+   *   // value must equal 42
    *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -153,15 +153,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed64 {
+   *   // value must equal 42
    *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -175,16 +175,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -196,16 +196,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -222,16 +222,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than or equal to 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -243,16 +243,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than or equal to 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -269,24 +269,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than 5 [fixed64.gt]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than 5 [fixed64.gt]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -298,24 +298,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than 5 [fixed64.gt]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than 5 [fixed64.gt]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -332,24 +332,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than or equal to 5 [fixed64.gte]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than or equal to 5 [fixed64.gte]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -361,24 +361,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than or equal to 5 [fixed64.gte]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than or equal to 5 [fixed64.gte]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -398,16 +398,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -420,16 +420,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -440,16 +440,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -467,16 +467,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -489,16 +489,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -509,16 +509,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1164,15 +1164,15 @@ private static final long serialVersionUID = 0L;
     private long const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed64 {
+     *   // value must equal 42
      *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1184,15 +1184,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed64 {
+     *   // value must equal 42
      *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1204,15 +1204,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed64 {
+     *   // value must equal 42
      *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1228,15 +1228,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyFixed64 {
+     *   // value must equal 42
      *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1251,16 +1251,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1271,16 +1271,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1294,16 +1294,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1319,16 +1319,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1345,16 +1345,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than or equal to 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1365,16 +1365,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than or equal to 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1388,16 +1388,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than or equal to 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1413,16 +1413,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be less than or equal to 10
      *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1439,24 +1439,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than 5 [fixed64.gt]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than 5 [fixed64.gt]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1467,24 +1467,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than 5 [fixed64.gt]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than 5 [fixed64.gt]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1498,24 +1498,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than 5 [fixed64.gt]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than 5 [fixed64.gt]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1531,24 +1531,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than 5 [fixed64.gt]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than 5 [fixed64.gt]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1565,24 +1565,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than or equal to 5 [fixed64.gte]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than or equal to 5 [fixed64.gte]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1593,24 +1593,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than or equal to 5 [fixed64.gte]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than or equal to 5 [fixed64.gte]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1624,24 +1624,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than or equal to 5 [fixed64.gte]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than or equal to 5 [fixed64.gte]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1657,24 +1657,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be greater than or equal to 5 [fixed64.gte]
-     *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be greater than or equal to 5 [fixed64.gte]
+     *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-     *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+     *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-     *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+     *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1704,16 +1704,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1726,16 +1726,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1746,16 +1746,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1767,16 +1767,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1795,16 +1795,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1821,16 +1821,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1848,16 +1848,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1885,16 +1885,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1907,16 +1907,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1927,16 +1927,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1948,16 +1948,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1976,16 +1976,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2002,16 +2002,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2029,16 +2029,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/Fixed64RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/Fixed64RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface Fixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed64 {
+   *   // value must equal 42
    *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface Fixed64RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyFixed64 {
+   *   // value must equal 42
    *   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional fixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface Fixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface Fixed64RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface Fixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than or equal to 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface Fixed64RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be less than or equal to 10
    *   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface Fixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than 5 [fixed64.gt]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than 5 [fixed64.gt]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface Fixed64RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than 5 [fixed64.gt]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than 5 [fixed64.gt]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface Fixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than or equal to 5 [fixed64.gte]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than or equal to 5 [fixed64.gte]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface Fixed64RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be greater than or equal to 5 [fixed64.gte]
-   *  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be greater than or equal to 5 [fixed64.gte]
+   *   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-   *  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+   *   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-   *  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+   *   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>fixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface Fixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface Fixed64RulesOrBuilder extends
   java.util.List<java.lang.Long> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface Fixed64RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface Fixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface Fixed64RulesOrBuilder extends
   java.util.List<java.lang.Long> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface Fixed64RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated fixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/FloatRules.java
+++ b/src/main/java/build/buf/validate/FloatRules.java
@@ -134,15 +134,15 @@ private static final long serialVersionUID = 0L;
   private float const_ = 0F;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyFloat {
+   *   // value must equal 42.0
    *   float value = 1 [(buf.validate.field).float.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,15 +154,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyFloat {
+   *   // value must equal 42.0
    *   float value = 1 [(buf.validate.field).float.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -176,16 +176,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than 10.0
    *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -197,16 +197,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than 10.0
    *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -223,16 +223,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than or equal to 10.0
    *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -244,16 +244,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than or equal to 10.0
    *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -270,24 +270,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than 5.0 [float.gt]
-   *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than 5.0 [float.gt]
+   *   float value = 1 [(buf.validate.field).float.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -299,24 +299,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than 5.0 [float.gt]
-   *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than 5.0 [float.gt]
+   *   float value = 1 [(buf.validate.field).float.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -333,24 +333,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than or equal to 5.0 [float.gte]
-   *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than or equal to 5.0 [float.gte]
+   *   float value = 1 [(buf.validate.field).float.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -362,24 +362,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than or equal to 5.0 [float.gte]
-   *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than or equal to 5.0 [float.gte]
+   *   float value = 1 [(buf.validate.field).float.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -399,16 +399,16 @@ private static final long serialVersionUID = 0L;
       emptyFloatList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -421,16 +421,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -441,16 +441,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -468,16 +468,16 @@ private static final long serialVersionUID = 0L;
       emptyFloatList();
   /**
    * <pre>
-   *`in` requires the field value to not be equal to any of the specified
+   * `in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -490,16 +490,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to not be equal to any of the specified
+   * `in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -510,16 +510,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to not be equal to any of the specified
+   * `in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -535,7 +535,7 @@ private static final long serialVersionUID = 0L;
   private boolean finite_ = false;
   /**
    * <pre>
-   *`finite` requires the field value to be finite. If the field value is
+   * `finite` requires the field value to be finite. If the field value is
    * infinite or NaN, an error message is generated.
    * </pre>
    *
@@ -1211,15 +1211,15 @@ private static final long serialVersionUID = 0L;
     private float const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyFloat {
+     *   // value must equal 42.0
      *   float value = 1 [(buf.validate.field).float.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1231,15 +1231,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyFloat {
+     *   // value must equal 42.0
      *   float value = 1 [(buf.validate.field).float.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1251,15 +1251,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyFloat {
+     *   // value must equal 42.0
      *   float value = 1 [(buf.validate.field).float.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1275,15 +1275,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must equal 42.0
+     * ```proto
+     * message MyFloat {
+     *   // value must equal 42.0
      *   float value = 1 [(buf.validate.field).float.const = 42.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1298,16 +1298,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than 10.0
      *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1318,16 +1318,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than 10.0
      *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1341,16 +1341,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than 10.0
      *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1366,16 +1366,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than 10.0
      *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1392,16 +1392,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than or equal to 10.0
      *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1412,16 +1412,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than or equal to 10.0
      *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1435,16 +1435,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than or equal to 10.0
      *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1460,16 +1460,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be less than or equal to 10.0
+     * ```proto
+     * message MyFloat {
+     *   // value must be less than or equal to 10.0
      *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1486,24 +1486,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than 5.0 [float.gt]
-     *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than 5.0 [float.gt]
+     *   float value = 1 [(buf.validate.field).float.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1514,24 +1514,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than 5.0 [float.gt]
-     *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than 5.0 [float.gt]
+     *   float value = 1 [(buf.validate.field).float.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1545,24 +1545,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than 5.0 [float.gt]
-     *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than 5.0 [float.gt]
+     *   float value = 1 [(buf.validate.field).float.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1578,24 +1578,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than 5.0 [float.gt]
-     *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than 5.0 [float.gt]
+     *   float value = 1 [(buf.validate.field).float.gt = 5.0];
      *
-     *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+     *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1612,24 +1612,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than or equal to 5.0 [float.gte]
-     *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than or equal to 5.0 [float.gte]
+     *   float value = 1 [(buf.validate.field).float.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1640,24 +1640,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than or equal to 5.0 [float.gte]
-     *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than or equal to 5.0 [float.gte]
+     *   float value = 1 [(buf.validate.field).float.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1671,24 +1671,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than or equal to 5.0 [float.gte]
-     *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than or equal to 5.0 [float.gte]
+     *   float value = 1 [(buf.validate.field).float.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1704,24 +1704,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be greater than or equal to 5.0 [float.gte]
-     *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+     * ```proto
+     * message MyFloat {
+     *   // value must be greater than or equal to 5.0 [float.gte]
+     *   float value = 1 [(buf.validate.field).float.gte = 5.0];
      *
-     *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-     *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+     *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+     *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
      *
-     *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-     *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+     *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1751,16 +1751,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1773,16 +1773,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1793,16 +1793,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1814,16 +1814,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1842,16 +1842,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1868,16 +1868,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1895,16 +1895,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1932,16 +1932,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to not be equal to any of the specified
+     * `in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1954,16 +1954,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to not be equal to any of the specified
+     * `in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1974,16 +1974,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to not be equal to any of the specified
+     * `in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1995,16 +1995,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to not be equal to any of the specified
+     * `in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2023,16 +2023,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to not be equal to any of the specified
+     * `in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2049,16 +2049,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to not be equal to any of the specified
+     * `in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2076,16 +2076,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to not be equal to any of the specified
+     * `in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyFloat {
-     *  // value must not be in list [1.0, 2.0, 3.0]
-     *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-     *}
-     *```
+     * ```proto
+     * message MyFloat {
+     *   // value must not be in list [1.0, 2.0, 3.0]
+     *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2101,7 +2101,7 @@ private static final long serialVersionUID = 0L;
     private boolean finite_ ;
     /**
      * <pre>
-     *`finite` requires the field value to be finite. If the field value is
+     * `finite` requires the field value to be finite. If the field value is
      * infinite or NaN, an error message is generated.
      * </pre>
      *
@@ -2114,7 +2114,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`finite` requires the field value to be finite. If the field value is
+     * `finite` requires the field value to be finite. If the field value is
      * infinite or NaN, an error message is generated.
      * </pre>
      *
@@ -2131,7 +2131,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`finite` requires the field value to be finite. If the field value is
+     * `finite` requires the field value to be finite. If the field value is
      * infinite or NaN, an error message is generated.
      * </pre>
      *

--- a/src/main/java/build/buf/validate/FloatRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/FloatRulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyFloat {
+   *   // value must equal 42.0
    *   float value = 1 [(buf.validate.field).float.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface FloatRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must equal 42.0
+   * ```proto
+   * message MyFloat {
+   *   // value must equal 42.0
    *   float value = 1 [(buf.validate.field).float.const = 42.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional float const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than 10.0
    *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface FloatRulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than 10.0
    *   float value = 1 [(buf.validate.field).float.lt = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than or equal to 10.0
    *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface FloatRulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be less than or equal to 10.0
+   * ```proto
+   * message MyFloat {
+   *   // value must be less than or equal to 10.0
    *   float value = 1 [(buf.validate.field).float.lte = 10.0];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>float lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than 5.0 [float.gt]
-   *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than 5.0 [float.gt]
+   *   float value = 1 [(buf.validate.field).float.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface FloatRulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than 5.0 [float.gt]
-   *  float value = 1 [(buf.validate.field).float.gt = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than 5.0 [float.gt]
+   *   float value = 1 [(buf.validate.field).float.gt = 5.0];
    *
-   *  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+   *   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than or equal to 5.0 [float.gte]
-   *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than or equal to 5.0 [float.gte]
+   *   float value = 1 [(buf.validate.field).float.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface FloatRulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be greater than or equal to 5.0 [float.gte]
-   *  float value = 1 [(buf.validate.field).float.gte = 5.0];
+   * ```proto
+   * message MyFloat {
+   *   // value must be greater than or equal to 5.0 [float.gte]
+   *   float value = 1 [(buf.validate.field).float.gte = 5.0];
    *
-   *  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-   *  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+   *   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+   *   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
    *
-   *  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-   *  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+   *   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>float gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface FloatRulesOrBuilder extends
   java.util.List<java.lang.Float> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface FloatRulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to not be equal to any of the specified
+   * `in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface FloatRulesOrBuilder extends
   java.util.List<java.lang.Float> getNotInList();
   /**
    * <pre>
-   *`in` requires the field value to not be equal to any of the specified
+   * `in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface FloatRulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`in` requires the field value to not be equal to any of the specified
+   * `in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyFloat {
-   *  // value must not be in list [1.0, 2.0, 3.0]
-   *  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-   *}
-   *```
+   * ```proto
+   * message MyFloat {
+   *   // value must not be in list [1.0, 2.0, 3.0]
+   *   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated float not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -336,7 +336,7 @@ public interface FloatRulesOrBuilder extends
 
   /**
    * <pre>
-   *`finite` requires the field value to be finite. If the field value is
+   * `finite` requires the field value to be finite. If the field value is
    * infinite or NaN, an error message is generated.
    * </pre>
    *

--- a/src/main/java/build/buf/validate/Int32Rules.java
+++ b/src/main/java/build/buf/validate/Int32Rules.java
@@ -134,15 +134,15 @@ private static final long serialVersionUID = 0L;
   private int const_ = 0;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt32 {
+   *   // value must equal 42
    *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,15 +154,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt32 {
+   *   // value must equal 42
    *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -180,12 +180,12 @@ private static final long serialVersionUID = 0L;
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than 10
    *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -201,12 +201,12 @@ private static final long serialVersionUID = 0L;
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than 10
    *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -223,16 +223,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than or equal to 10
    *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -244,16 +244,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than or equal to 10
    *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -270,24 +270,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than 5 [int32.gt]
-   *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than 5 [int32.gt]
+   *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -299,24 +299,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than 5 [int32.gt]
-   *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than 5 [int32.gt]
+   *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -333,24 +333,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified value
+   * `gte` requires the field value to be greater than or equal to the specified value
    * (exclusive). If the value of `gte` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than or equal to 5 [int32.gte]
-   *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than or equal to 5 [int32.gte]
+   *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -362,24 +362,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified value
+   * `gte` requires the field value to be greater than or equal to the specified value
    * (exclusive). If the value of `gte` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than or equal to 5 [int32.gte]
-   *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than or equal to 5 [int32.gte]
+   *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -399,16 +399,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -421,16 +421,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -441,16 +441,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -468,16 +468,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -490,16 +490,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -510,16 +510,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1165,15 +1165,15 @@ private static final long serialVersionUID = 0L;
     private int const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt32 {
+     *   // value must equal 42
      *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1185,15 +1185,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt32 {
+     *   // value must equal 42
      *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1205,15 +1205,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt32 {
+     *   // value must equal 42
      *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1229,15 +1229,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt32 {
+     *   // value must equal 42
      *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1256,12 +1256,12 @@ private static final long serialVersionUID = 0L;
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than 10
      *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1276,12 +1276,12 @@ private static final long serialVersionUID = 0L;
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than 10
      *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1299,12 +1299,12 @@ private static final long serialVersionUID = 0L;
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than 10
      *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1324,12 +1324,12 @@ private static final long serialVersionUID = 0L;
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than 10
      *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1346,16 +1346,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than or equal to 10
      *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1366,16 +1366,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than or equal to 10
      *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1389,16 +1389,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than or equal to 10
      *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1414,16 +1414,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt32 {
+     *   // value must be less than or equal to 10
      *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1440,24 +1440,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than 5 [int32.gt]
-     *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than 5 [int32.gt]
+     *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1468,24 +1468,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than 5 [int32.gt]
-     *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than 5 [int32.gt]
+     *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1499,24 +1499,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than 5 [int32.gt]
-     *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than 5 [int32.gt]
+     *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1532,24 +1532,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than 5 [int32.gt]
-     *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than 5 [int32.gt]
+     *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1566,24 +1566,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified value
+     * `gte` requires the field value to be greater than or equal to the specified value
      * (exclusive). If the value of `gte` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than or equal to 5 [int32.gte]
-     *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than or equal to 5 [int32.gte]
+     *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1594,24 +1594,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified value
+     * `gte` requires the field value to be greater than or equal to the specified value
      * (exclusive). If the value of `gte` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than or equal to 5 [int32.gte]
-     *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than or equal to 5 [int32.gte]
+     *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1625,24 +1625,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified value
+     * `gte` requires the field value to be greater than or equal to the specified value
      * (exclusive). If the value of `gte` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than or equal to 5 [int32.gte]
-     *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than or equal to 5 [int32.gte]
+     *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1658,24 +1658,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified value
+     * `gte` requires the field value to be greater than or equal to the specified value
      * (exclusive). If the value of `gte` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be greater than or equal to 5 [int32.gte]
-     *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+     * ```proto
+     * message MyInt32 {
+     *   // value must be greater than or equal to 5 [int32.gte]
+     *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-     *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+     *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-     *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+     *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1699,16 +1699,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1721,16 +1721,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1741,16 +1741,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1762,16 +1762,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1790,16 +1790,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1816,16 +1816,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1843,16 +1843,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1874,16 +1874,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1896,16 +1896,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1916,16 +1916,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1937,16 +1937,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1965,16 +1965,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1991,16 +1991,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2018,16 +2018,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MyInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/Int32RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/Int32RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface Int32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt32 {
+   *   // value must equal 42
    *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface Int32RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt32 {
+   *   // value must equal 42
    *   int32 value = 1 [(buf.validate.field).int32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -48,12 +48,12 @@ public interface Int32RulesOrBuilder extends
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than 10
    *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -66,12 +66,12 @@ public interface Int32RulesOrBuilder extends
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than 10
    *   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface Int32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than or equal to 10
    *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface Int32RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt32 {
+   *   // value must be less than or equal to 10
    *   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface Int32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than 5 [int32.gt]
-   *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than 5 [int32.gt]
+   *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface Int32RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than 5 [int32.gt]
-   *  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than 5 [int32.gt]
+   *   int32 value = 1 [(buf.validate.field).int32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int32.gt_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int32.gt_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface Int32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified value
+   * `gte` requires the field value to be greater than or equal to the specified value
    * (exclusive). If the value of `gte` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than or equal to 5 [int32.gte]
-   *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than or equal to 5 [int32.gte]
+   *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface Int32RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified value
+   * `gte` requires the field value to be greater than or equal to the specified value
    * (exclusive). If the value of `gte` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be greater than or equal to 5 [int32.gte]
-   *  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+   * ```proto
+   * message MyInt32 {
+   *   // value must be greater than or equal to 5 [int32.gte]
+   *   int32 value = 1 [(buf.validate.field).int32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-   *  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+   *   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-   *  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+   *   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface Int32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface Int32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface Int32RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface Int32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface Int32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface Int32RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MyInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/Int64Rules.java
+++ b/src/main/java/build/buf/validate/Int64Rules.java
@@ -134,15 +134,15 @@ private static final long serialVersionUID = 0L;
   private long const_ = 0L;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt64 {
+   *   // value must equal 42
    *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,15 +154,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt64 {
+   *   // value must equal 42
    *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -176,16 +176,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than 10
    *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -197,16 +197,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than 10
    *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -223,16 +223,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than or equal to 10
    *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -244,16 +244,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than or equal to 10
    *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -270,24 +270,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than 5 [int64.gt]
-   *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than 5 [int64.gt]
+   *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -299,24 +299,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than 5 [int64.gt]
-   *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than 5 [int64.gt]
+   *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -333,24 +333,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than or equal to 5 [int64.gte]
-   *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than or equal to 5 [int64.gte]
+   *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -362,24 +362,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than or equal to 5 [int64.gte]
-   *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than or equal to 5 [int64.gte]
+   *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -399,16 +399,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -421,16 +421,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -441,16 +441,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -468,16 +468,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -490,16 +490,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -510,16 +510,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1170,15 +1170,15 @@ private static final long serialVersionUID = 0L;
     private long const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt64 {
+     *   // value must equal 42
      *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1190,15 +1190,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt64 {
+     *   // value must equal 42
      *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1210,15 +1210,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt64 {
+     *   // value must equal 42
      *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1234,15 +1234,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyInt64 {
+     *   // value must equal 42
      *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1257,16 +1257,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than 10
      *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1277,16 +1277,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than 10
      *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1300,16 +1300,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than 10
      *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1325,16 +1325,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than 10
      *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1351,16 +1351,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than or equal to 10
      *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1371,16 +1371,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than or equal to 10
      *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1394,16 +1394,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than or equal to 10
      *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1419,16 +1419,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyInt64 {
+     *   // value must be less than or equal to 10
      *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1445,24 +1445,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than 5 [int64.gt]
-     *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than 5 [int64.gt]
+     *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1473,24 +1473,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than 5 [int64.gt]
-     *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than 5 [int64.gt]
+     *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1504,24 +1504,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than 5 [int64.gt]
-     *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than 5 [int64.gt]
+     *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1537,24 +1537,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than 5 [int64.gt]
-     *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than 5 [int64.gt]
+     *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1571,24 +1571,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than or equal to 5 [int64.gte]
-     *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than or equal to 5 [int64.gte]
+     *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1599,24 +1599,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than or equal to 5 [int64.gte]
-     *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than or equal to 5 [int64.gte]
+     *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1630,24 +1630,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than or equal to 5 [int64.gte]
-     *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than or equal to 5 [int64.gte]
+     *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1663,24 +1663,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be greater than or equal to 5 [int64.gte]
-     *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+     * ```proto
+     * message MyInt64 {
+     *   // value must be greater than or equal to 5 [int64.gte]
+     *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-     *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+     *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-     *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+     *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1704,16 +1704,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1726,16 +1726,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1746,16 +1746,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1767,16 +1767,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1795,16 +1795,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1821,16 +1821,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1848,16 +1848,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1879,16 +1879,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1901,16 +1901,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1921,16 +1921,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1942,16 +1942,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1970,16 +1970,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1996,16 +1996,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2023,16 +2023,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/Int64RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/Int64RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface Int64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt64 {
+   *   // value must equal 42
    *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface Int64RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyInt64 {
+   *   // value must equal 42
    *   int64 value = 1 [(buf.validate.field).int64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional int64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface Int64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than 10
    *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface Int64RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than 10
    *   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface Int64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than or equal to 10
    *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface Int64RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyInt64 {
+   *   // value must be less than or equal to 10
    *   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface Int64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than 5 [int64.gt]
-   *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than 5 [int64.gt]
+   *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface Int64RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than 5 [int64.gt]
-   *  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than 5 [int64.gt]
+   *   int64 value = 1 [(buf.validate.field).int64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [int64.gt_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [int64.gt_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface Int64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than or equal to 5 [int64.gte]
-   *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than or equal to 5 [int64.gte]
+   *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface Int64RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be greater than or equal to 5 [int64.gte]
-   *  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+   * ```proto
+   * message MyInt64 {
+   *   // value must be greater than or equal to 5 [int64.gte]
+   *   int64 value = 1 [(buf.validate.field).int64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-   *  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+   *   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-   *  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+   *   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>int64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface Int64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface Int64RulesOrBuilder extends
   java.util.List<java.lang.Long> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface Int64RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface Int64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface Int64RulesOrBuilder extends
   java.util.List<java.lang.Long> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface Int64RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated int64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/MapRules.java
+++ b/src/main/java/build/buf/validate/MapRules.java
@@ -48,14 +48,14 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    *Specifies the minimum number of key-value pairs allowed. If the field has
-   *fewer key-value pairs than specified, an error message is generated.
+   * fewer key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at least 2 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at least 2 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -68,14 +68,14 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    *Specifies the minimum number of key-value pairs allowed. If the field has
-   *fewer key-value pairs than specified, an error message is generated.
+   * fewer key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at least 2 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at least 2 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -91,14 +91,14 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    *Specifies the maximum number of key-value pairs allowed. If the field has
-   *more key-value pairs than specified, an error message is generated.
+   * more key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at most 3 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at most 3 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -111,14 +111,14 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    *Specifies the maximum number of key-value pairs allowed. If the field has
-   *more key-value pairs than specified, an error message is generated.
+   * more key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at most 3 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at most 3 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -135,17 +135,17 @@ private static final long serialVersionUID = 0L;
    * <pre>
    *Specifies the constraints to be applied to each key in the field.
    *
-   *```proto
-   *message MyMap {
-   *  // The keys in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The keys in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -159,17 +159,17 @@ private static final long serialVersionUID = 0L;
    * <pre>
    *Specifies the constraints to be applied to each key in the field.
    *
-   *```proto
-   *message MyMap {
-   *  // The keys in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The keys in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -183,17 +183,17 @@ private static final long serialVersionUID = 0L;
    * <pre>
    *Specifies the constraints to be applied to each key in the field.
    *
-   *```proto
-   *message MyMap {
-   *  // The keys in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The keys in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -208,20 +208,20 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    *Specifies the constraints to be applied to the value of each key in the
-   *field. Message values will still have their validations evaluated unless
+   * field. Message values will still have their validations evaluated unless
    *skip is specified here.
    *
-   *```proto
-   *message MyMap {
-   *  // The values in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-   *    string: {
-   *      min_len: 5
-   *      max_len: 20
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The values in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+   *     string: {
+   *       min_len: 5
+   *       max_len: 20
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -234,20 +234,20 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    *Specifies the constraints to be applied to the value of each key in the
-   *field. Message values will still have their validations evaluated unless
+   * field. Message values will still have their validations evaluated unless
    *skip is specified here.
    *
-   *```proto
-   *message MyMap {
-   *  // The values in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-   *    string: {
-   *      min_len: 5
-   *      max_len: 20
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The values in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+   *     string: {
+   *       min_len: 5
+   *       max_len: 20
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -260,20 +260,20 @@ private static final long serialVersionUID = 0L;
   /**
    * <pre>
    *Specifies the constraints to be applied to the value of each key in the
-   *field. Message values will still have their validations evaluated unless
+   * field. Message values will still have their validations evaluated unless
    *skip is specified here.
    *
-   *```proto
-   *message MyMap {
-   *  // The values in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-   *    string: {
-   *      min_len: 5
-   *      max_len: 20
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The values in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+   *     string: {
+   *       min_len: 5
+   *       max_len: 20
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -736,14 +736,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the minimum number of key-value pairs allowed. If the field has
-     *fewer key-value pairs than specified, an error message is generated.
+     * fewer key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at least 2 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at least 2 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -756,14 +756,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the minimum number of key-value pairs allowed. If the field has
-     *fewer key-value pairs than specified, an error message is generated.
+     * fewer key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at least 2 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at least 2 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -776,14 +776,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the minimum number of key-value pairs allowed. If the field has
-     *fewer key-value pairs than specified, an error message is generated.
+     * fewer key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at least 2 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at least 2 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -800,14 +800,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the minimum number of key-value pairs allowed. If the field has
-     *fewer key-value pairs than specified, an error message is generated.
+     * fewer key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at least 2 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at least 2 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -824,14 +824,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the maximum number of key-value pairs allowed. If the field has
-     *more key-value pairs than specified, an error message is generated.
+     * more key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at most 3 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at most 3 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -844,14 +844,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the maximum number of key-value pairs allowed. If the field has
-     *more key-value pairs than specified, an error message is generated.
+     * more key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at most 3 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at most 3 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -864,14 +864,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the maximum number of key-value pairs allowed. If the field has
-     *more key-value pairs than specified, an error message is generated.
+     * more key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at most 3 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at most 3 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -888,14 +888,14 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the maximum number of key-value pairs allowed. If the field has
-     *more key-value pairs than specified, an error message is generated.
+     * more key-value pairs than specified, an error message is generated.
      *
-     *```proto
-     *message MyMap {
-     *  // The field `value` must have at most 3 key-value pairs.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The field `value` must have at most 3 key-value pairs.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -915,17 +915,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -938,17 +938,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -965,17 +965,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -997,17 +997,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -1027,17 +1027,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -1064,17 +1064,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -1093,17 +1093,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -1117,17 +1117,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -1144,17 +1144,17 @@ private static final long serialVersionUID = 0L;
      * <pre>
      *Specifies the constraints to be applied to each key in the field.
      *
-     *```proto
-     *message MyMap {
-     *  // The keys in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The keys in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -1179,20 +1179,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1204,20 +1204,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1233,20 +1233,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1267,20 +1267,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1299,20 +1299,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1338,20 +1338,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1369,20 +1369,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1395,20 +1395,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -1424,20 +1424,20 @@ private static final long serialVersionUID = 0L;
     /**
      * <pre>
      *Specifies the constraints to be applied to the value of each key in the
-     *field. Message values will still have their validations evaluated unless
+     * field. Message values will still have their validations evaluated unless
      *skip is specified here.
      *
-     *```proto
-     *message MyMap {
-     *  // The values in the field `value` must follow the specified constraints.
-     *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-     *    string: {
-     *      min_len: 5
-     *      max_len: 20
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyMap {
+     *   // The values in the field `value` must follow the specified constraints.
+     *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+     *     string: {
+     *       min_len: 5
+     *       max_len: 20
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>

--- a/src/main/java/build/buf/validate/MapRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/MapRulesOrBuilder.java
@@ -10,14 +10,14 @@ public interface MapRulesOrBuilder extends
   /**
    * <pre>
    *Specifies the minimum number of key-value pairs allowed. If the field has
-   *fewer key-value pairs than specified, an error message is generated.
+   * fewer key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at least 2 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at least 2 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -27,14 +27,14 @@ public interface MapRulesOrBuilder extends
   /**
    * <pre>
    *Specifies the minimum number of key-value pairs allowed. If the field has
-   *fewer key-value pairs than specified, an error message is generated.
+   * fewer key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at least 2 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at least 2 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.min_pairs = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_pairs = 1 [json_name = "minPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -45,14 +45,14 @@ public interface MapRulesOrBuilder extends
   /**
    * <pre>
    *Specifies the maximum number of key-value pairs allowed. If the field has
-   *more key-value pairs than specified, an error message is generated.
+   * more key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at most 3 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at most 3 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -62,14 +62,14 @@ public interface MapRulesOrBuilder extends
   /**
    * <pre>
    *Specifies the maximum number of key-value pairs allowed. If the field has
-   *more key-value pairs than specified, an error message is generated.
+   * more key-value pairs than specified, an error message is generated.
    *
-   *```proto
-   *message MyMap {
-   *  // The field `value` must have at most 3 key-value pairs.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The field `value` must have at most 3 key-value pairs.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.max_pairs = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_pairs = 2 [json_name = "maxPairs", (.buf.validate.priv.field) = { ... }</code>
@@ -81,17 +81,17 @@ public interface MapRulesOrBuilder extends
    * <pre>
    *Specifies the constraints to be applied to each key in the field.
    *
-   *```proto
-   *message MyMap {
-   *  // The keys in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The keys in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -102,17 +102,17 @@ public interface MapRulesOrBuilder extends
    * <pre>
    *Specifies the constraints to be applied to each key in the field.
    *
-   *```proto
-   *message MyMap {
-   *  // The keys in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The keys in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -123,17 +123,17 @@ public interface MapRulesOrBuilder extends
    * <pre>
    *Specifies the constraints to be applied to each key in the field.
    *
-   *```proto
-   *message MyMap {
-   *  // The keys in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The keys in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.keys = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints keys = 4 [json_name = "keys"];</code>
@@ -143,20 +143,20 @@ public interface MapRulesOrBuilder extends
   /**
    * <pre>
    *Specifies the constraints to be applied to the value of each key in the
-   *field. Message values will still have their validations evaluated unless
+   * field. Message values will still have their validations evaluated unless
    *skip is specified here.
    *
-   *```proto
-   *message MyMap {
-   *  // The values in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-   *    string: {
-   *      min_len: 5
-   *      max_len: 20
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The values in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+   *     string: {
+   *       min_len: 5
+   *       max_len: 20
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -166,20 +166,20 @@ public interface MapRulesOrBuilder extends
   /**
    * <pre>
    *Specifies the constraints to be applied to the value of each key in the
-   *field. Message values will still have their validations evaluated unless
+   * field. Message values will still have their validations evaluated unless
    *skip is specified here.
    *
-   *```proto
-   *message MyMap {
-   *  // The values in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-   *    string: {
-   *      min_len: 5
-   *      max_len: 20
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The values in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+   *     string: {
+   *       min_len: 5
+   *       max_len: 20
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>
@@ -189,20 +189,20 @@ public interface MapRulesOrBuilder extends
   /**
    * <pre>
    *Specifies the constraints to be applied to the value of each key in the
-   *field. Message values will still have their validations evaluated unless
+   * field. Message values will still have their validations evaluated unless
    *skip is specified here.
    *
-   *```proto
-   *message MyMap {
-   *  // The values in the field `value` must follow the specified constraints.
-   *  map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
-   *    string: {
-   *      min_len: 5
-   *      max_len: 20
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyMap {
+   *   // The values in the field `value` must follow the specified constraints.
+   *   map&lt;string, string&gt; value = 1 [(buf.validate.field).map.values = {
+   *     string: {
+   *       min_len: 5
+   *       max_len: 20
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints values = 5 [json_name = "values"];</code>

--- a/src/main/java/build/buf/validate/MessageConstraints.java
+++ b/src/main/java/build/buf/validate/MessageConstraints.java
@@ -49,7 +49,7 @@ private static final long serialVersionUID = 0L;
   private boolean disabled_ = false;
   /**
    * <pre>
-   * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+   * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
    * This includes any fields within the message that would otherwise support validation.
    *
    * ```proto
@@ -69,7 +69,7 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+   * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
    * This includes any fields within the message that would otherwise support validation.
    *
    * ```proto
@@ -93,22 +93,22 @@ private static final long serialVersionUID = 0L;
   private java.util.List<build.buf.validate.Constraint> cel_;
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -119,22 +119,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -146,22 +146,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -172,22 +172,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -198,22 +198,22 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -638,7 +638,7 @@ private static final long serialVersionUID = 0L;
     private boolean disabled_ ;
     /**
      * <pre>
-     * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+     * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
      * This includes any fields within the message that would otherwise support validation.
      *
      * ```proto
@@ -658,7 +658,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+     * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
      * This includes any fields within the message that would otherwise support validation.
      *
      * ```proto
@@ -678,7 +678,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+     * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
      * This includes any fields within the message that would otherwise support validation.
      *
      * ```proto
@@ -702,7 +702,7 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+     * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
      * This includes any fields within the message that would otherwise support validation.
      *
      * ```proto
@@ -737,22 +737,22 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -766,22 +766,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -795,22 +795,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -824,22 +824,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -860,22 +860,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -893,22 +893,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -928,22 +928,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -964,22 +964,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -997,22 +997,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1030,22 +1030,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1064,22 +1064,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1096,22 +1096,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1128,22 +1128,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1154,22 +1154,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1183,22 +1183,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1213,22 +1213,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1239,22 +1239,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -1266,22 +1266,22 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+     * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
      * These constraints are written in Common Expression Language (CEL) syntax. For more information on
      * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
      *
      *
-     *```proto
-     *message MyMessage {
-     *  // The field `foo` must be greater than 42.
-     *  option (buf.validate.message).cel = {
-     *    id: "my_message.value",
-     *    message: "value must be greater than 42",
-     *    expression: "this.foo &gt; 42",
-     *  };
-     *  optional int32 foo = 1;
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   // The field `foo` must be greater than 42.
+     *   option (buf.validate.message).cel = {
+     *     id: "my_message.value",
+     *     message: "value must be greater than 42",
+     *     expression: "this.foo &gt; 42",
+     *   };
+     *   optional int32 foo = 1;
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>

--- a/src/main/java/build/buf/validate/MessageConstraintsOrBuilder.java
+++ b/src/main/java/build/buf/validate/MessageConstraintsOrBuilder.java
@@ -9,7 +9,7 @@ public interface MessageConstraintsOrBuilder extends
 
   /**
    * <pre>
-   * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+   * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
    * This includes any fields within the message that would otherwise support validation.
    *
    * ```proto
@@ -26,7 +26,7 @@ public interface MessageConstraintsOrBuilder extends
   boolean hasDisabled();
   /**
    * <pre>
-   * disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+   * `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
    * This includes any fields within the message that would otherwise support validation.
    *
    * ```proto
@@ -44,22 +44,22 @@ public interface MessageConstraintsOrBuilder extends
 
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -68,22 +68,22 @@ public interface MessageConstraintsOrBuilder extends
       getCelList();
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -91,22 +91,22 @@ public interface MessageConstraintsOrBuilder extends
   build.buf.validate.Constraint getCel(int index);
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -114,22 +114,22 @@ public interface MessageConstraintsOrBuilder extends
   int getCelCount();
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>
@@ -138,22 +138,22 @@ public interface MessageConstraintsOrBuilder extends
       getCelOrBuilderList();
   /**
    * <pre>
-   * cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+   * `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
    * These constraints are written in Common Expression Language (CEL) syntax. For more information on
    * CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
    *
    *
-   *```proto
-   *message MyMessage {
-   *  // The field `foo` must be greater than 42.
-   *  option (buf.validate.message).cel = {
-   *    id: "my_message.value",
-   *    message: "value must be greater than 42",
-   *    expression: "this.foo &gt; 42",
-   *  };
-   *  optional int32 foo = 1;
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   // The field `foo` must be greater than 42.
+   *   option (buf.validate.message).cel = {
+   *     id: "my_message.value",
+   *     message: "value must be greater than 42",
+   *     expression: "this.foo &gt; 42",
+   *   };
+   *   optional int32 foo = 1;
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated .buf.validate.Constraint cel = 3 [json_name = "cel"];</code>

--- a/src/main/java/build/buf/validate/OneofConstraints.java
+++ b/src/main/java/build/buf/validate/OneofConstraints.java
@@ -50,20 +50,20 @@ private static final long serialVersionUID = 0L;
   private boolean required_ = false;
   /**
    * <pre>
-   *`required` is an optional boolean attribute that ensures that
-   *exactly one of the field options in a oneof is set; validation fails if
-   *no fields in the oneof are set.
+   * `required` is an optional boolean attribute that ensures that
+   * exactly one of the field options in a oneof is set; validation fails if
+   * no fields in the oneof are set.
    *
-   *```proto
-   *message MyMessage {
-   *  oneof value {
-   *    // The field `a` or `b` must be set.
-   *    option (buf.validate.oneof).required = true;
-   *    optional string a = 1;
-   *    optional string b = 2;
-   *  }
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   oneof value {
+   *     // The field `a` or `b` must be set.
+   *     option (buf.validate.oneof).required = true;
+   *     optional string a = 1;
+   *     optional string b = 2;
+   *   }
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool required = 1 [json_name = "required"];</code>
@@ -75,20 +75,20 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`required` is an optional boolean attribute that ensures that
-   *exactly one of the field options in a oneof is set; validation fails if
-   *no fields in the oneof are set.
+   * `required` is an optional boolean attribute that ensures that
+   * exactly one of the field options in a oneof is set; validation fails if
+   * no fields in the oneof are set.
    *
-   *```proto
-   *message MyMessage {
-   *  oneof value {
-   *    // The field `a` or `b` must be set.
-   *    option (buf.validate.oneof).required = true;
-   *    optional string a = 1;
-   *    optional string b = 2;
-   *  }
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   oneof value {
+   *     // The field `a` or `b` must be set.
+   *     option (buf.validate.oneof).required = true;
+   *     optional string a = 1;
+   *     optional string b = 2;
+   *   }
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool required = 1 [json_name = "required"];</code>
@@ -443,20 +443,20 @@ private static final long serialVersionUID = 0L;
     private boolean required_ ;
     /**
      * <pre>
-     *`required` is an optional boolean attribute that ensures that
-     *exactly one of the field options in a oneof is set; validation fails if
-     *no fields in the oneof are set.
+     * `required` is an optional boolean attribute that ensures that
+     * exactly one of the field options in a oneof is set; validation fails if
+     * no fields in the oneof are set.
      *
-     *```proto
-     *message MyMessage {
-     *  oneof value {
-     *    // The field `a` or `b` must be set.
-     *    option (buf.validate.oneof).required = true;
-     *    optional string a = 1;
-     *    optional string b = 2;
-     *  }
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   oneof value {
+     *     // The field `a` or `b` must be set.
+     *     option (buf.validate.oneof).required = true;
+     *     optional string a = 1;
+     *     optional string b = 2;
+     *   }
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool required = 1 [json_name = "required"];</code>
@@ -468,20 +468,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`required` is an optional boolean attribute that ensures that
-     *exactly one of the field options in a oneof is set; validation fails if
-     *no fields in the oneof are set.
+     * `required` is an optional boolean attribute that ensures that
+     * exactly one of the field options in a oneof is set; validation fails if
+     * no fields in the oneof are set.
      *
-     *```proto
-     *message MyMessage {
-     *  oneof value {
-     *    // The field `a` or `b` must be set.
-     *    option (buf.validate.oneof).required = true;
-     *    optional string a = 1;
-     *    optional string b = 2;
-     *  }
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   oneof value {
+     *     // The field `a` or `b` must be set.
+     *     option (buf.validate.oneof).required = true;
+     *     optional string a = 1;
+     *     optional string b = 2;
+     *   }
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool required = 1 [json_name = "required"];</code>
@@ -493,20 +493,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`required` is an optional boolean attribute that ensures that
-     *exactly one of the field options in a oneof is set; validation fails if
-     *no fields in the oneof are set.
+     * `required` is an optional boolean attribute that ensures that
+     * exactly one of the field options in a oneof is set; validation fails if
+     * no fields in the oneof are set.
      *
-     *```proto
-     *message MyMessage {
-     *  oneof value {
-     *    // The field `a` or `b` must be set.
-     *    option (buf.validate.oneof).required = true;
-     *    optional string a = 1;
-     *    optional string b = 2;
-     *  }
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   oneof value {
+     *     // The field `a` or `b` must be set.
+     *     option (buf.validate.oneof).required = true;
+     *     optional string a = 1;
+     *     optional string b = 2;
+     *   }
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool required = 1 [json_name = "required"];</code>
@@ -522,20 +522,20 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`required` is an optional boolean attribute that ensures that
-     *exactly one of the field options in a oneof is set; validation fails if
-     *no fields in the oneof are set.
+     * `required` is an optional boolean attribute that ensures that
+     * exactly one of the field options in a oneof is set; validation fails if
+     * no fields in the oneof are set.
      *
-     *```proto
-     *message MyMessage {
-     *  oneof value {
-     *    // The field `a` or `b` must be set.
-     *    option (buf.validate.oneof).required = true;
-     *    optional string a = 1;
-     *    optional string b = 2;
-     *  }
-     *}
-     *```
+     * ```proto
+     * message MyMessage {
+     *   oneof value {
+     *     // The field `a` or `b` must be set.
+     *     option (buf.validate.oneof).required = true;
+     *     optional string a = 1;
+     *     optional string b = 2;
+     *   }
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool required = 1 [json_name = "required"];</code>

--- a/src/main/java/build/buf/validate/OneofConstraintsOrBuilder.java
+++ b/src/main/java/build/buf/validate/OneofConstraintsOrBuilder.java
@@ -9,20 +9,20 @@ public interface OneofConstraintsOrBuilder extends
 
   /**
    * <pre>
-   *`required` is an optional boolean attribute that ensures that
-   *exactly one of the field options in a oneof is set; validation fails if
-   *no fields in the oneof are set.
+   * `required` is an optional boolean attribute that ensures that
+   * exactly one of the field options in a oneof is set; validation fails if
+   * no fields in the oneof are set.
    *
-   *```proto
-   *message MyMessage {
-   *  oneof value {
-   *    // The field `a` or `b` must be set.
-   *    option (buf.validate.oneof).required = true;
-   *    optional string a = 1;
-   *    optional string b = 2;
-   *  }
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   oneof value {
+   *     // The field `a` or `b` must be set.
+   *     option (buf.validate.oneof).required = true;
+   *     optional string a = 1;
+   *     optional string b = 2;
+   *   }
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool required = 1 [json_name = "required"];</code>
@@ -31,20 +31,20 @@ public interface OneofConstraintsOrBuilder extends
   boolean hasRequired();
   /**
    * <pre>
-   *`required` is an optional boolean attribute that ensures that
-   *exactly one of the field options in a oneof is set; validation fails if
-   *no fields in the oneof are set.
+   * `required` is an optional boolean attribute that ensures that
+   * exactly one of the field options in a oneof is set; validation fails if
+   * no fields in the oneof are set.
    *
-   *```proto
-   *message MyMessage {
-   *  oneof value {
-   *    // The field `a` or `b` must be set.
-   *    option (buf.validate.oneof).required = true;
-   *    optional string a = 1;
-   *    optional string b = 2;
-   *  }
-   *}
-   *```
+   * ```proto
+   * message MyMessage {
+   *   oneof value {
+   *     // The field `a` or `b` must be set.
+   *     option (buf.validate.oneof).required = true;
+   *     optional string a = 1;
+   *     optional string b = 2;
+   *   }
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool required = 1 [json_name = "required"];</code>

--- a/src/main/java/build/buf/validate/RepeatedRules.java
+++ b/src/main/java/build/buf/validate/RepeatedRules.java
@@ -47,15 +47,17 @@ private static final long serialVersionUID = 0L;
   private long minItems_ = 0L;
   /**
    * <pre>
-   *`min_items` requires that this field must contain at least the specified
-   *minimum number of items.
+   * `min_items` requires that this field must contain at least the specified
+   * minimum number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain at least  2 items
-   *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-   *}
-   *```
+   * Note that `min_items = 1` is equivalent to setting a field as `required`.
+   *
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain at least  2 items
+   *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -67,15 +69,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`min_items` requires that this field must contain at least the specified
-   *minimum number of items.
+   * `min_items` requires that this field must contain at least the specified
+   * minimum number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain at least  2 items
-   *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-   *}
-   *```
+   * Note that `min_items = 1` is equivalent to setting a field as `required`.
+   *
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain at least  2 items
+   *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -90,17 +94,17 @@ private static final long serialVersionUID = 0L;
   private long maxItems_ = 0L;
   /**
    * <pre>
-   *`max_items` denotes that this field must not exceed a
-   *certain number of items as the upper limit. If the field contains more
-   *items than specified, an error message will be generated, requiring the
-   *field to maintain no more than the specified number of items.
+   * `max_items` denotes that this field must not exceed a
+   * certain number of items as the upper limit. If the field contains more
+   * items than specified, an error message will be generated, requiring the
+   * field to maintain no more than the specified number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain no more than 3 item(s)
-   *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain no more than 3 item(s)
+   *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -112,17 +116,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`max_items` denotes that this field must not exceed a
-   *certain number of items as the upper limit. If the field contains more
-   *items than specified, an error message will be generated, requiring the
-   *field to maintain no more than the specified number of items.
+   * `max_items` denotes that this field must not exceed a
+   * certain number of items as the upper limit. If the field contains more
+   * items than specified, an error message will be generated, requiring the
+   * field to maintain no more than the specified number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain no more than 3 item(s)
-   *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain no more than 3 item(s)
+   *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -137,16 +141,16 @@ private static final long serialVersionUID = 0L;
   private boolean unique_ = false;
   /**
    * <pre>
-   *`unique` indicates that all elements in this field must
-   *be unique. This constraint is strictly applicable to scalar and enum
-   *types, with message types not being supported.
+   * `unique` indicates that all elements in this field must
+   * be unique. This constraint is strictly applicable to scalar and enum
+   * types, with message types not being supported.
    *
-   *```proto
-   *message MyRepeated {
-   *  // repeated value must contain unique items
-   *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // repeated value must contain unique items
+   *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -158,16 +162,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`unique` indicates that all elements in this field must
-   *be unique. This constraint is strictly applicable to scalar and enum
-   *types, with message types not being supported.
+   * `unique` indicates that all elements in this field must
+   * be unique. This constraint is strictly applicable to scalar and enum
+   * types, with message types not being supported.
    *
-   *```proto
-   *message MyRepeated {
-   *  // repeated value must contain unique items
-   *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // repeated value must contain unique items
+   *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -182,21 +186,21 @@ private static final long serialVersionUID = 0L;
   private build.buf.validate.FieldConstraints items_;
   /**
    * <pre>
-   *`items` details the constraints to be applied to each item
-   *in the field. Even for repeated message fields, validation is executed
-   *against each item unless skip is explicitly specified.
+   * `items` details the constraints to be applied to each item
+   * in the field. Even for repeated message fields, validation is executed
+   * against each item unless skip is explicitly specified.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The items in the field `value` must follow the specified constraints.
-   *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The items in the field `value` must follow the specified constraints.
+   *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -208,21 +212,21 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`items` details the constraints to be applied to each item
-   *in the field. Even for repeated message fields, validation is executed
-   *against each item unless skip is explicitly specified.
+   * `items` details the constraints to be applied to each item
+   * in the field. Even for repeated message fields, validation is executed
+   * against each item unless skip is explicitly specified.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The items in the field `value` must follow the specified constraints.
-   *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The items in the field `value` must follow the specified constraints.
+   *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -234,21 +238,21 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`items` details the constraints to be applied to each item
-   *in the field. Even for repeated message fields, validation is executed
-   *against each item unless skip is explicitly specified.
+   * `items` details the constraints to be applied to each item
+   * in the field. Even for repeated message fields, validation is executed
+   * against each item unless skip is explicitly specified.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The items in the field `value` must follow the specified constraints.
-   *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The items in the field `value` must follow the specified constraints.
+   *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -702,15 +706,17 @@ private static final long serialVersionUID = 0L;
     private long minItems_ ;
     /**
      * <pre>
-     *`min_items` requires that this field must contain at least the specified
-     *minimum number of items.
+     * `min_items` requires that this field must contain at least the specified
+     * minimum number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain at least  2 items
-     *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-     *}
-     *```
+     * Note that `min_items = 1` is equivalent to setting a field as `required`.
+     *
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain at least  2 items
+     *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -722,15 +728,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_items` requires that this field must contain at least the specified
-     *minimum number of items.
+     * `min_items` requires that this field must contain at least the specified
+     * minimum number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain at least  2 items
-     *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-     *}
-     *```
+     * Note that `min_items = 1` is equivalent to setting a field as `required`.
+     *
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain at least  2 items
+     *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -742,15 +750,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_items` requires that this field must contain at least the specified
-     *minimum number of items.
+     * `min_items` requires that this field must contain at least the specified
+     * minimum number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain at least  2 items
-     *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-     *}
-     *```
+     * Note that `min_items = 1` is equivalent to setting a field as `required`.
+     *
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain at least  2 items
+     *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -766,15 +776,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_items` requires that this field must contain at least the specified
-     *minimum number of items.
+     * `min_items` requires that this field must contain at least the specified
+     * minimum number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain at least  2 items
-     *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-     *}
-     *```
+     * Note that `min_items = 1` is equivalent to setting a field as `required`.
+     *
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain at least  2 items
+     *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -790,17 +802,17 @@ private static final long serialVersionUID = 0L;
     private long maxItems_ ;
     /**
      * <pre>
-     *`max_items` denotes that this field must not exceed a
-     *certain number of items as the upper limit. If the field contains more
-     *items than specified, an error message will be generated, requiring the
-     *field to maintain no more than the specified number of items.
+     * `max_items` denotes that this field must not exceed a
+     * certain number of items as the upper limit. If the field contains more
+     * items than specified, an error message will be generated, requiring the
+     * field to maintain no more than the specified number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain no more than 3 item(s)
-     *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain no more than 3 item(s)
+     *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -812,17 +824,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_items` denotes that this field must not exceed a
-     *certain number of items as the upper limit. If the field contains more
-     *items than specified, an error message will be generated, requiring the
-     *field to maintain no more than the specified number of items.
+     * `max_items` denotes that this field must not exceed a
+     * certain number of items as the upper limit. If the field contains more
+     * items than specified, an error message will be generated, requiring the
+     * field to maintain no more than the specified number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain no more than 3 item(s)
-     *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain no more than 3 item(s)
+     *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -834,17 +846,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_items` denotes that this field must not exceed a
-     *certain number of items as the upper limit. If the field contains more
-     *items than specified, an error message will be generated, requiring the
-     *field to maintain no more than the specified number of items.
+     * `max_items` denotes that this field must not exceed a
+     * certain number of items as the upper limit. If the field contains more
+     * items than specified, an error message will be generated, requiring the
+     * field to maintain no more than the specified number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain no more than 3 item(s)
-     *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain no more than 3 item(s)
+     *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -860,17 +872,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_items` denotes that this field must not exceed a
-     *certain number of items as the upper limit. If the field contains more
-     *items than specified, an error message will be generated, requiring the
-     *field to maintain no more than the specified number of items.
+     * `max_items` denotes that this field must not exceed a
+     * certain number of items as the upper limit. If the field contains more
+     * items than specified, an error message will be generated, requiring the
+     * field to maintain no more than the specified number of items.
      *
-     *```proto
-     *message MyRepeated {
-     *  // value must contain no more than 3 item(s)
-     *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // value must contain no more than 3 item(s)
+     *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -886,16 +898,16 @@ private static final long serialVersionUID = 0L;
     private boolean unique_ ;
     /**
      * <pre>
-     *`unique` indicates that all elements in this field must
-     *be unique. This constraint is strictly applicable to scalar and enum
-     *types, with message types not being supported.
+     * `unique` indicates that all elements in this field must
+     * be unique. This constraint is strictly applicable to scalar and enum
+     * types, with message types not being supported.
      *
-     *```proto
-     *message MyRepeated {
-     *  // repeated value must contain unique items
-     *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // repeated value must contain unique items
+     *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -907,16 +919,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`unique` indicates that all elements in this field must
-     *be unique. This constraint is strictly applicable to scalar and enum
-     *types, with message types not being supported.
+     * `unique` indicates that all elements in this field must
+     * be unique. This constraint is strictly applicable to scalar and enum
+     * types, with message types not being supported.
      *
-     *```proto
-     *message MyRepeated {
-     *  // repeated value must contain unique items
-     *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // repeated value must contain unique items
+     *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -928,16 +940,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`unique` indicates that all elements in this field must
-     *be unique. This constraint is strictly applicable to scalar and enum
-     *types, with message types not being supported.
+     * `unique` indicates that all elements in this field must
+     * be unique. This constraint is strictly applicable to scalar and enum
+     * types, with message types not being supported.
      *
-     *```proto
-     *message MyRepeated {
-     *  // repeated value must contain unique items
-     *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // repeated value must contain unique items
+     *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -953,16 +965,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`unique` indicates that all elements in this field must
-     *be unique. This constraint is strictly applicable to scalar and enum
-     *types, with message types not being supported.
+     * `unique` indicates that all elements in this field must
+     * be unique. This constraint is strictly applicable to scalar and enum
+     * types, with message types not being supported.
      *
-     *```proto
-     *message MyRepeated {
-     *  // repeated value must contain unique items
-     *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // repeated value must contain unique items
+     *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -980,21 +992,21 @@ private static final long serialVersionUID = 0L;
         build.buf.validate.FieldConstraints, build.buf.validate.FieldConstraints.Builder, build.buf.validate.FieldConstraintsOrBuilder> itemsBuilder_;
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1005,21 +1017,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1034,21 +1046,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1068,21 +1080,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1100,21 +1112,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1139,21 +1151,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1170,21 +1182,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1196,21 +1208,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -1225,21 +1237,21 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`items` details the constraints to be applied to each item
-     *in the field. Even for repeated message fields, validation is executed
-     *against each item unless skip is explicitly specified.
+     * `items` details the constraints to be applied to each item
+     * in the field. Even for repeated message fields, validation is executed
+     * against each item unless skip is explicitly specified.
      *
-     *```proto
-     *message MyRepeated {
-     *  // The items in the field `value` must follow the specified constraints.
-     *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-     *    string: {
-     *      min_len: 3
-     *      max_len: 10
-     *    }
-     *  }];
-     *}
-     *```
+     * ```proto
+     * message MyRepeated {
+     *   // The items in the field `value` must follow the specified constraints.
+     *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+     *     string: {
+     *       min_len: 3
+     *       max_len: 10
+     *     }
+     *   }];
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>

--- a/src/main/java/build/buf/validate/RepeatedRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/RepeatedRulesOrBuilder.java
@@ -9,15 +9,17 @@ public interface RepeatedRulesOrBuilder extends
 
   /**
    * <pre>
-   *`min_items` requires that this field must contain at least the specified
-   *minimum number of items.
+   * `min_items` requires that this field must contain at least the specified
+   * minimum number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain at least  2 items
-   *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-   *}
-   *```
+   * Note that `min_items = 1` is equivalent to setting a field as `required`.
+   *
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain at least  2 items
+   *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +28,17 @@ public interface RepeatedRulesOrBuilder extends
   boolean hasMinItems();
   /**
    * <pre>
-   *`min_items` requires that this field must contain at least the specified
-   *minimum number of items.
+   * `min_items` requires that this field must contain at least the specified
+   * minimum number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain at least  2 items
-   *  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-   *}
-   *```
+   * Note that `min_items = 1` is equivalent to setting a field as `required`.
+   *
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain at least  2 items
+   *   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_items = 1 [json_name = "minItems", (.buf.validate.priv.field) = { ... }</code>
@@ -44,17 +48,17 @@ public interface RepeatedRulesOrBuilder extends
 
   /**
    * <pre>
-   *`max_items` denotes that this field must not exceed a
-   *certain number of items as the upper limit. If the field contains more
-   *items than specified, an error message will be generated, requiring the
-   *field to maintain no more than the specified number of items.
+   * `max_items` denotes that this field must not exceed a
+   * certain number of items as the upper limit. If the field contains more
+   * items than specified, an error message will be generated, requiring the
+   * field to maintain no more than the specified number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain no more than 3 item(s)
-   *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain no more than 3 item(s)
+   *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -63,17 +67,17 @@ public interface RepeatedRulesOrBuilder extends
   boolean hasMaxItems();
   /**
    * <pre>
-   *`max_items` denotes that this field must not exceed a
-   *certain number of items as the upper limit. If the field contains more
-   *items than specified, an error message will be generated, requiring the
-   *field to maintain no more than the specified number of items.
+   * `max_items` denotes that this field must not exceed a
+   * certain number of items as the upper limit. If the field contains more
+   * items than specified, an error message will be generated, requiring the
+   * field to maintain no more than the specified number of items.
    *
-   *```proto
-   *message MyRepeated {
-   *  // value must contain no more than 3 item(s)
-   *  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // value must contain no more than 3 item(s)
+   *   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_items = 2 [json_name = "maxItems", (.buf.validate.priv.field) = { ... }</code>
@@ -83,16 +87,16 @@ public interface RepeatedRulesOrBuilder extends
 
   /**
    * <pre>
-   *`unique` indicates that all elements in this field must
-   *be unique. This constraint is strictly applicable to scalar and enum
-   *types, with message types not being supported.
+   * `unique` indicates that all elements in this field must
+   * be unique. This constraint is strictly applicable to scalar and enum
+   * types, with message types not being supported.
    *
-   *```proto
-   *message MyRepeated {
-   *  // repeated value must contain unique items
-   *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // repeated value must contain unique items
+   *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -101,16 +105,16 @@ public interface RepeatedRulesOrBuilder extends
   boolean hasUnique();
   /**
    * <pre>
-   *`unique` indicates that all elements in this field must
-   *be unique. This constraint is strictly applicable to scalar and enum
-   *types, with message types not being supported.
+   * `unique` indicates that all elements in this field must
+   * be unique. This constraint is strictly applicable to scalar and enum
+   * types, with message types not being supported.
    *
-   *```proto
-   *message MyRepeated {
-   *  // repeated value must contain unique items
-   *  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // repeated value must contain unique items
+   *   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool unique = 3 [json_name = "unique", (.buf.validate.priv.field) = { ... }</code>
@@ -120,21 +124,21 @@ public interface RepeatedRulesOrBuilder extends
 
   /**
    * <pre>
-   *`items` details the constraints to be applied to each item
-   *in the field. Even for repeated message fields, validation is executed
-   *against each item unless skip is explicitly specified.
+   * `items` details the constraints to be applied to each item
+   * in the field. Even for repeated message fields, validation is executed
+   * against each item unless skip is explicitly specified.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The items in the field `value` must follow the specified constraints.
-   *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The items in the field `value` must follow the specified constraints.
+   *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -143,21 +147,21 @@ public interface RepeatedRulesOrBuilder extends
   boolean hasItems();
   /**
    * <pre>
-   *`items` details the constraints to be applied to each item
-   *in the field. Even for repeated message fields, validation is executed
-   *against each item unless skip is explicitly specified.
+   * `items` details the constraints to be applied to each item
+   * in the field. Even for repeated message fields, validation is executed
+   * against each item unless skip is explicitly specified.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The items in the field `value` must follow the specified constraints.
-   *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The items in the field `value` must follow the specified constraints.
+   *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>
@@ -166,21 +170,21 @@ public interface RepeatedRulesOrBuilder extends
   build.buf.validate.FieldConstraints getItems();
   /**
    * <pre>
-   *`items` details the constraints to be applied to each item
-   *in the field. Even for repeated message fields, validation is executed
-   *against each item unless skip is explicitly specified.
+   * `items` details the constraints to be applied to each item
+   * in the field. Even for repeated message fields, validation is executed
+   * against each item unless skip is explicitly specified.
    *
-   *```proto
-   *message MyRepeated {
-   *  // The items in the field `value` must follow the specified constraints.
-   *  repeated string value = 1 [(buf.validate.field).repeated.items = {
-   *    string: {
-   *      min_len: 3
-   *      max_len: 10
-   *    }
-   *  }];
-   *}
-   *```
+   * ```proto
+   * message MyRepeated {
+   *   // The items in the field `value` must follow the specified constraints.
+   *   repeated string value = 1 [(buf.validate.field).repeated.items = {
+   *     string: {
+   *       min_len: 3
+   *       max_len: 10
+   *     }
+   *   }];
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .buf.validate.FieldConstraints items = 4 [json_name = "items"];</code>

--- a/src/main/java/build/buf/validate/SFixed32Rules.java
+++ b/src/main/java/build/buf/validate/SFixed32Rules.java
@@ -133,15 +133,15 @@ private static final long serialVersionUID = 0L;
   private int const_ = 0;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed32 {
+   *   // value must equal 42
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -153,15 +153,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed32 {
+   *   // value must equal 42
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -175,16 +175,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -196,16 +196,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -222,16 +222,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than or equal to 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -243,16 +243,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than or equal to 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -269,24 +269,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than 5 [sfixed32.gt]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than 5 [sfixed32.gt]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -298,24 +298,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than 5 [sfixed32.gt]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than 5 [sfixed32.gt]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -332,24 +332,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than or equal to 5 [sfixed32.gte]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than or equal to 5 [sfixed32.gte]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -361,24 +361,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than or equal to 5 [sfixed32.gte]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than or equal to 5 [sfixed32.gte]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -398,16 +398,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -420,16 +420,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -440,16 +440,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -467,16 +467,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -489,16 +489,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -509,16 +509,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1159,15 +1159,15 @@ private static final long serialVersionUID = 0L;
     private int const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed32 {
+     *   // value must equal 42
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1179,15 +1179,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed32 {
+     *   // value must equal 42
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1199,15 +1199,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed32 {
+     *   // value must equal 42
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1223,15 +1223,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed32 {
+     *   // value must equal 42
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1246,16 +1246,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1266,16 +1266,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1289,16 +1289,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1314,16 +1314,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1340,16 +1340,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than or equal to 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1360,16 +1360,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than or equal to 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1383,16 +1383,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than or equal to 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1408,16 +1408,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be less than or equal to 10
      *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1434,24 +1434,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than 5 [sfixed32.gt]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than 5 [sfixed32.gt]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1462,24 +1462,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than 5 [sfixed32.gt]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than 5 [sfixed32.gt]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1493,24 +1493,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than 5 [sfixed32.gt]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than 5 [sfixed32.gt]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1526,24 +1526,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than 5 [sfixed32.gt]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than 5 [sfixed32.gt]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1560,24 +1560,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than or equal to 5 [sfixed32.gte]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than or equal to 5 [sfixed32.gte]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1588,24 +1588,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than or equal to 5 [sfixed32.gte]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than or equal to 5 [sfixed32.gte]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1619,24 +1619,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than or equal to 5 [sfixed32.gte]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than or equal to 5 [sfixed32.gte]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1652,24 +1652,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be greater than or equal to 5 [sfixed32.gte]
-     *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be greater than or equal to 5 [sfixed32.gte]
+     *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-     *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+     *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-     *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+     *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1699,16 +1699,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1721,16 +1721,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1741,16 +1741,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1762,16 +1762,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1790,16 +1790,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1816,16 +1816,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1843,16 +1843,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1880,16 +1880,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1902,16 +1902,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1922,16 +1922,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1943,16 +1943,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1971,16 +1971,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1997,16 +1997,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2024,16 +2024,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/SFixed32RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/SFixed32RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface SFixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed32 {
+   *   // value must equal 42
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface SFixed32RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed32 {
+   *   // value must equal 42
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface SFixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface SFixed32RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface SFixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than or equal to 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface SFixed32RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be less than or equal to 10
    *   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface SFixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than 5 [sfixed32.gt]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than 5 [sfixed32.gt]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface SFixed32RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than 5 [sfixed32.gt]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than 5 [sfixed32.gt]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface SFixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than or equal to 5 [sfixed32.gte]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than or equal to 5 [sfixed32.gte]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface SFixed32RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be greater than or equal to 5 [sfixed32.gte]
-   *  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be greater than or equal to 5 [sfixed32.gte]
+   *   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-   *  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+   *   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-   *  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+   *   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface SFixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface SFixed32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface SFixed32RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface SFixed32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface SFixed32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface SFixed32RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/SFixed64Rules.java
+++ b/src/main/java/build/buf/validate/SFixed64Rules.java
@@ -133,15 +133,15 @@ private static final long serialVersionUID = 0L;
   private long const_ = 0L;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed64 {
+   *   // value must equal 42
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -153,15 +153,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed64 {
+   *   // value must equal 42
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -175,16 +175,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -196,16 +196,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -222,16 +222,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than or equal to 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -243,16 +243,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than or equal to 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -269,24 +269,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than 5 [sfixed64.gt]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than 5 [sfixed64.gt]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -298,24 +298,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than 5 [sfixed64.gt]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than 5 [sfixed64.gt]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -332,24 +332,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than or equal to 5 [sfixed64.gte]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than or equal to 5 [sfixed64.gte]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -361,24 +361,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than or equal to 5 [sfixed64.gte]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than or equal to 5 [sfixed64.gte]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -398,16 +398,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -420,16 +420,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -440,16 +440,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -467,16 +467,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -489,16 +489,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -509,16 +509,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1164,15 +1164,15 @@ private static final long serialVersionUID = 0L;
     private long const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed64 {
+     *   // value must equal 42
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1184,15 +1184,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed64 {
+     *   // value must equal 42
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1204,15 +1204,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed64 {
+     *   // value must equal 42
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1228,15 +1228,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySFixed64 {
+     *   // value must equal 42
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1251,16 +1251,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1271,16 +1271,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1294,16 +1294,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1319,16 +1319,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1345,16 +1345,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than or equal to 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1365,16 +1365,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than or equal to 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1388,16 +1388,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than or equal to 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1413,16 +1413,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be less than or equal to 10
      *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1439,24 +1439,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than 5 [sfixed64.gt]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than 5 [sfixed64.gt]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1467,24 +1467,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than 5 [sfixed64.gt]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than 5 [sfixed64.gt]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1498,24 +1498,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than 5 [sfixed64.gt]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than 5 [sfixed64.gt]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1531,24 +1531,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than 5 [sfixed64.gt]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than 5 [sfixed64.gt]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1565,24 +1565,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than or equal to 5 [sfixed64.gte]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than or equal to 5 [sfixed64.gte]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1593,24 +1593,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than or equal to 5 [sfixed64.gte]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than or equal to 5 [sfixed64.gte]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1624,24 +1624,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than or equal to 5 [sfixed64.gte]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than or equal to 5 [sfixed64.gte]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1657,24 +1657,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be greater than or equal to 5 [sfixed64.gte]
-     *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be greater than or equal to 5 [sfixed64.gte]
+     *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-     *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+     *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-     *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+     *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1704,16 +1704,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1726,16 +1726,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1746,16 +1746,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1767,16 +1767,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1795,16 +1795,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1821,16 +1821,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1848,16 +1848,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1885,16 +1885,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1907,16 +1907,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1927,16 +1927,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1948,16 +1948,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1976,16 +1976,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2002,16 +2002,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2029,16 +2029,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySFixed64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySFixed64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/SFixed64RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/SFixed64RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface SFixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed64 {
+   *   // value must equal 42
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface SFixed64RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySFixed64 {
+   *   // value must equal 42
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sfixed64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface SFixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface SFixed64RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface SFixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than or equal to 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface SFixed64RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be less than or equal to 10
    *   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface SFixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than 5 [sfixed64.gt]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than 5 [sfixed64.gt]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface SFixed64RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than 5 [sfixed64.gt]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than 5 [sfixed64.gt]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface SFixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than or equal to 5 [sfixed64.gte]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than or equal to 5 [sfixed64.gte]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface SFixed64RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be greater than or equal to 5 [sfixed64.gte]
-   *  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be greater than or equal to 5 [sfixed64.gte]
+   *   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-   *  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+   *   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-   *  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+   *   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sfixed64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface SFixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface SFixed64RulesOrBuilder extends
   java.util.List<java.lang.Long> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface SFixed64RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface SFixed64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface SFixed64RulesOrBuilder extends
   java.util.List<java.lang.Long> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface SFixed64RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySFixed64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySFixed64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sfixed64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/SInt32Rules.java
+++ b/src/main/java/build/buf/validate/SInt32Rules.java
@@ -133,15 +133,15 @@ private static final long serialVersionUID = 0L;
   private int const_ = 0;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt32 {
+   *   // value must equal 42
    *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -153,15 +153,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt32 {
+   *   // value must equal 42
    *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -175,16 +175,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -196,16 +196,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -222,16 +222,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than or equal to 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -243,16 +243,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than or equal to 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -269,24 +269,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be greater than 5 [sint32.gt]
-   *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+   * ```proto
+   * message MySInt32 {
+   *   // value must be greater than 5 [sint32.gt]
+   *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-   *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+   *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-   *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+   *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -298,24 +298,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be greater than 5 [sint32.gt]
-   *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+   * ```proto
+   * message MySInt32 {
+   *   // value must be greater than 5 [sint32.gt]
+   *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-   *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+   *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-   *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+   *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -332,14 +332,14 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
+   * ```proto
+   * message MySInt32 {
    *  // value must be greater than or equal to 5 [sint32.gte]
    *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
    *
@@ -348,8 +348,8 @@ private static final long serialVersionUID = 0L;
    *
    *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
    *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -361,14 +361,14 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
+   * ```proto
+   * message MySInt32 {
    *  // value must be greater than or equal to 5 [sint32.gte]
    *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
    *
@@ -377,8 +377,8 @@ private static final long serialVersionUID = 0L;
    *
    *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
    *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -398,16 +398,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -420,16 +420,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -440,16 +440,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -467,16 +467,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -489,16 +489,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -509,16 +509,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1163,15 +1163,15 @@ private static final long serialVersionUID = 0L;
     private int const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt32 {
+     *   // value must equal 42
      *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1183,15 +1183,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt32 {
+     *   // value must equal 42
      *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1203,15 +1203,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt32 {
+     *   // value must equal 42
      *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1227,15 +1227,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt32 {
+     *   // value must equal 42
      *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1250,16 +1250,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1270,16 +1270,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1293,16 +1293,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1318,16 +1318,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1344,16 +1344,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than or equal to 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1364,16 +1364,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than or equal to 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1387,16 +1387,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than or equal to 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1412,16 +1412,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt32 {
+     *   // value must be less than or equal to 10
      *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1438,24 +1438,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be greater than 5 [sint32.gt]
-     *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+     * ```proto
+     * message MySInt32 {
+     *   // value must be greater than 5 [sint32.gt]
+     *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-     *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+     *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-     *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+     *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1466,24 +1466,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be greater than 5 [sint32.gt]
-     *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+     * ```proto
+     * message MySInt32 {
+     *   // value must be greater than 5 [sint32.gt]
+     *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-     *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+     *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-     *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+     *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1497,24 +1497,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be greater than 5 [sint32.gt]
-     *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+     * ```proto
+     * message MySInt32 {
+     *   // value must be greater than 5 [sint32.gt]
+     *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-     *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+     *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-     *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+     *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1530,24 +1530,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be greater than 5 [sint32.gt]
-     *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+     * ```proto
+     * message MySInt32 {
+     *   // value must be greater than 5 [sint32.gt]
+     *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-     *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+     *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-     *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+     *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1564,14 +1564,14 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
+     * ```proto
+     * message MySInt32 {
      *  // value must be greater than or equal to 5 [sint32.gte]
      *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
      *
@@ -1580,8 +1580,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
      *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1592,14 +1592,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
+     * ```proto
+     * message MySInt32 {
      *  // value must be greater than or equal to 5 [sint32.gte]
      *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
      *
@@ -1608,8 +1608,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
      *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1623,14 +1623,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
+     * ```proto
+     * message MySInt32 {
      *  // value must be greater than or equal to 5 [sint32.gte]
      *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
      *
@@ -1639,8 +1639,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
      *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1656,14 +1656,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt32 {
+     * ```proto
+     * message MySInt32 {
      *  // value must be greater than or equal to 5 [sint32.gte]
      *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
      *
@@ -1672,8 +1672,8 @@ private static final long serialVersionUID = 0L;
      *
      *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
      *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1697,16 +1697,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1719,16 +1719,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1739,16 +1739,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1760,16 +1760,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1788,16 +1788,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1814,16 +1814,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1841,16 +1841,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1872,16 +1872,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1894,16 +1894,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1914,16 +1914,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1935,16 +1935,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1963,16 +1963,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1989,16 +1989,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2016,16 +2016,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/SInt32RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/SInt32RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface SInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt32 {
+   *   // value must equal 42
    *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface SInt32RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt32 {
+   *   // value must equal 42
    *   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface SInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface SInt32RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface SInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than or equal to 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface SInt32RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt32 {
+   *   // value must be less than or equal to 10
    *   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface SInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be greater than 5 [sint32.gt]
-   *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+   * ```proto
+   * message MySInt32 {
+   *   // value must be greater than 5 [sint32.gt]
+   *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-   *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+   *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-   *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+   *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface SInt32RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be greater than 5 [sint32.gt]
-   *  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+   * ```proto
+   * message MySInt32 {
+   *   // value must be greater than 5 [sint32.gt]
+   *   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-   *  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+   *   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-   *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+   *   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,14 +171,14 @@ public interface SInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
+   * ```proto
+   * message MySInt32 {
    *  // value must be greater than or equal to 5 [sint32.gte]
    *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
    *
@@ -187,8 +187,8 @@ public interface SInt32RulesOrBuilder extends
    *
    *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
    *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,14 +197,14 @@ public interface SInt32RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt32 {
+   * ```proto
+   * message MySInt32 {
    *  // value must be greater than or equal to 5 [sint32.gte]
    *  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
    *
@@ -213,8 +213,8 @@ public interface SInt32RulesOrBuilder extends
    *
    *  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
    *  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface SInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface SInt32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface SInt32RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface SInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface SInt32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface SInt32RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/SInt64Rules.java
+++ b/src/main/java/build/buf/validate/SInt64Rules.java
@@ -133,15 +133,15 @@ private static final long serialVersionUID = 0L;
   private long const_ = 0L;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt64 {
+   *   // value must equal 42
    *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -153,15 +153,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt64 {
+   *   // value must equal 42
    *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -175,16 +175,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -196,16 +196,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -222,16 +222,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than or equal to 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -243,16 +243,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than or equal to 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -269,24 +269,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than 5 [sint64.gt]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than 5 [sint64.gt]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -298,24 +298,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than 5 [sint64.gt]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than 5 [sint64.gt]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -332,24 +332,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than or equal to 5 [sint64.gte]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than or equal to 5 [sint64.gte]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -361,24 +361,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than or equal to 5 [sint64.gte]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than or equal to 5 [sint64.gte]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -398,16 +398,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -420,16 +420,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -440,16 +440,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -467,16 +467,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -489,16 +489,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -509,16 +509,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1168,15 +1168,15 @@ private static final long serialVersionUID = 0L;
     private long const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt64 {
+     *   // value must equal 42
      *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1188,15 +1188,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt64 {
+     *   // value must equal 42
      *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1208,15 +1208,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt64 {
+     *   // value must equal 42
      *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1232,15 +1232,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MySInt64 {
+     *   // value must equal 42
      *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1255,16 +1255,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1275,16 +1275,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1298,16 +1298,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1323,16 +1323,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field
+     * `lt` requires the field value to be less than the specified value (field
      * &lt; value). If the field value is equal to or greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1349,16 +1349,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than or equal to 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1369,16 +1369,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than or equal to 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1392,16 +1392,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than or equal to 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1417,16 +1417,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MySInt64 {
+     *   // value must be less than or equal to 10
      *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1443,24 +1443,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than 5 [sint64.gt]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than 5 [sint64.gt]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1471,24 +1471,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than 5 [sint64.gt]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than 5 [sint64.gt]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1502,24 +1502,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than 5 [sint64.gt]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than 5 [sint64.gt]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1535,24 +1535,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than 5 [sint64.gt]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than 5 [sint64.gt]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1569,24 +1569,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than or equal to 5 [sint64.gte]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than or equal to 5 [sint64.gte]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1597,24 +1597,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than or equal to 5 [sint64.gte]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than or equal to 5 [sint64.gte]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1628,24 +1628,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than or equal to 5 [sint64.gte]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than or equal to 5 [sint64.gte]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1661,24 +1661,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be greater than or equal to 5 [sint64.gte]
-     *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+     * ```proto
+     * message MySInt64 {
+     *   // value must be greater than or equal to 5 [sint64.gte]
+     *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-     *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+     *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-     *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+     *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1702,16 +1702,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1724,16 +1724,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1744,16 +1744,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1765,16 +1765,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1793,16 +1793,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1819,16 +1819,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1846,16 +1846,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message
      * is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1877,16 +1877,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1899,16 +1899,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1919,16 +1919,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1940,16 +1940,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1968,16 +1968,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1994,16 +1994,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2021,16 +2021,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MySInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MySInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/SInt64RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/SInt64RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface SInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt64 {
+   *   // value must equal 42
    *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface SInt64RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MySInt64 {
+   *   // value must equal 42
    *   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional sint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface SInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface SInt64RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field
+   * `lt` requires the field value to be less than the specified value (field
    * &lt; value). If the field value is equal to or greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface SInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than or equal to 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface SInt64RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MySInt64 {
+   *   // value must be less than or equal to 10
    *   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface SInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than 5 [sint64.gt]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than 5 [sint64.gt]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface SInt64RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than 5 [sint64.gt]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than 5 [sint64.gt]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface SInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than or equal to 5 [sint64.gte]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than or equal to 5 [sint64.gte]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface SInt64RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be greater than or equal to 5 [sint64.gte]
-   *  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+   * ```proto
+   * message MySInt64 {
+   *   // value must be greater than or equal to 5 [sint64.gte]
+   *   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-   *  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+   *   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-   *  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+   *   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>sint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface SInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface SInt64RulesOrBuilder extends
   java.util.List<java.lang.Long> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface SInt64RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message
    * is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface SInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface SInt64RulesOrBuilder extends
   java.util.List<java.lang.Long> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface SInt64RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MySInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MySInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated sint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/StringRules.java
+++ b/src/main/java/build/buf/validate/StringRules.java
@@ -117,15 +117,15 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object const_ = "";
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
-   *the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified value. If
+   * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must equal `hello`
+   * ```proto
+   * message MyString {
+   *   // value must equal `hello`
    *   string value = 1 [(buf.validate.field).string.const = "hello"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -137,15 +137,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
-   *the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified value. If
+   * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must equal `hello`
+   * ```proto
+   * message MyString {
+   *   // value must equal `hello`
    *   string value = 1 [(buf.validate.field).string.const = "hello"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -166,15 +166,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
-   *the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified value. If
+   * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must equal `hello`
+   * ```proto
+   * message MyString {
+   *   // value must equal `hello`
    *   string value = 1 [(buf.validate.field).string.const = "hello"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -199,17 +199,17 @@ private static final long serialVersionUID = 0L;
   private long len_ = 0L;
   /**
    * <pre>
-   *`len` dictates that the field value must have the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value does not meet the specified
-   *length, an error message will be generated.
+   * `len` dictates that the field value must have the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value does not meet the specified
+   * length, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 5 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be 5 characters
    *   string value = 1 [(buf.validate.field).string.len = 5];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -221,17 +221,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`len` dictates that the field value must have the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value does not meet the specified
-   *length, an error message will be generated.
+   * `len` dictates that the field value must have the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value does not meet the specified
+   * length, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 5 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be 5 characters
    *   string value = 1 [(buf.validate.field).string.len = 5];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -246,17 +246,17 @@ private static final long serialVersionUID = 0L;
   private long minLen_ = 0L;
   /**
    * <pre>
-   *`min_len` specifies that the field value must have at least the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value contains fewer characters, an error
-   *message will be generated.
+   * `min_len` specifies that the field value must have at least the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value contains fewer characters, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 3 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 3 characters
    *   string value = 1 [(buf.validate.field).string.min_len = 3];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -268,17 +268,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`min_len` specifies that the field value must have at least the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value contains fewer characters, an error
-   *message will be generated.
+   * `min_len` specifies that the field value must have at least the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value contains fewer characters, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 3 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 3 characters
    *   string value = 1 [(buf.validate.field).string.min_len = 3];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -293,17 +293,17 @@ private static final long serialVersionUID = 0L;
   private long maxLen_ = 0L;
   /**
    * <pre>
-   *`max_len` specifies that the field value must have no more than the specified
-   *number of characters (Unicode code points), which may differ from the
-   *number of bytes in the string. If the field value contains more characters,
-   *an error message will be generated.
+   * `max_len` specifies that the field value must have no more than the specified
+   * number of characters (Unicode code points), which may differ from the
+   * number of bytes in the string. If the field value contains more characters,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 10 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 10 characters
    *   string value = 1 [(buf.validate.field).string.max_len = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -315,17 +315,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`max_len` specifies that the field value must have no more than the specified
-   *number of characters (Unicode code points), which may differ from the
-   *number of bytes in the string. If the field value contains more characters,
-   *an error message will be generated.
+   * `max_len` specifies that the field value must have no more than the specified
+   * number of characters (Unicode code points), which may differ from the
+   * number of bytes in the string. If the field value contains more characters,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 10 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 10 characters
    *   string value = 1 [(buf.validate.field).string.max_len = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -340,16 +340,16 @@ private static final long serialVersionUID = 0L;
   private long lenBytes_ = 0L;
   /**
    * <pre>
-   *`len_bytes` dictates that the field value must have the specified number of
-   *bytes. If the field value does not match the specified length in bytes,
-   *an error message will be generated.
+   * `len_bytes` dictates that the field value must have the specified number of
+   * bytes. If the field value does not match the specified length in bytes,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 6 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be 6 bytes
    *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -361,16 +361,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`len_bytes` dictates that the field value must have the specified number of
-   *bytes. If the field value does not match the specified length in bytes,
-   *an error message will be generated.
+   * `len_bytes` dictates that the field value must have the specified number of
+   * bytes. If the field value does not match the specified length in bytes,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 6 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be 6 bytes
    *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -385,17 +385,17 @@ private static final long serialVersionUID = 0L;
   private long minBytes_ = 0L;
   /**
    * <pre>
-   *`min_bytes` specifies that the field value must have at least the specified
-   *number of bytes. If the field value contains fewer bytes, an error message
-   *will be generated.
+   * `min_bytes` specifies that the field value must have at least the specified
+   * number of bytes. If the field value contains fewer bytes, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 4 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 4 bytes
    *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-   *}
+   * }
    *
-   *```
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -407,17 +407,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`min_bytes` specifies that the field value must have at least the specified
-   *number of bytes. If the field value contains fewer bytes, an error message
-   *will be generated.
+   * `min_bytes` specifies that the field value must have at least the specified
+   * number of bytes. If the field value contains fewer bytes, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 4 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 4 bytes
    *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-   *}
+   * }
    *
-   *```
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -432,16 +432,16 @@ private static final long serialVersionUID = 0L;
   private long maxBytes_ = 0L;
   /**
    * <pre>
-   *`max_bytes` specifies that the field value must have no more than the
+   * `max_bytes` specifies that the field value must have no more than the
    *specified number of bytes. If the field value contains more bytes, an
-   *error message will be generated.
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 8 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 8 bytes
    *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -453,16 +453,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`max_bytes` specifies that the field value must have no more than the
+   * `max_bytes` specifies that the field value must have no more than the
    *specified number of bytes. If the field value contains more bytes, an
-   *error message will be generated.
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 8 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 8 bytes
    *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -478,17 +478,17 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object pattern_ = "";
   /**
    * <pre>
-   *`pattern` specifies that the field value must match the specified
-   *regular expression (RE2 syntax), with the expression provided without any
-   *delimiters. If the field value doesn't match the regular expression, an
-   *error message will be generated.
+   * `pattern` specifies that the field value must match the specified
+   * regular expression (RE2 syntax), with the expression provided without any
+   * delimiters. If the field value doesn't match the regular expression, an
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not match regex pattern `^[a-zA-Z]//$`
+   * ```proto
+   * message MyString {
+   *   // value does not match regex pattern `^[a-zA-Z]//$`
    *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -500,17 +500,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`pattern` specifies that the field value must match the specified
-   *regular expression (RE2 syntax), with the expression provided without any
-   *delimiters. If the field value doesn't match the regular expression, an
-   *error message will be generated.
+   * `pattern` specifies that the field value must match the specified
+   * regular expression (RE2 syntax), with the expression provided without any
+   * delimiters. If the field value doesn't match the regular expression, an
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not match regex pattern `^[a-zA-Z]//$`
+   * ```proto
+   * message MyString {
+   *   // value does not match regex pattern `^[a-zA-Z]//$`
    *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -531,17 +531,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`pattern` specifies that the field value must match the specified
-   *regular expression (RE2 syntax), with the expression provided without any
-   *delimiters. If the field value doesn't match the regular expression, an
-   *error message will be generated.
+   * `pattern` specifies that the field value must match the specified
+   * regular expression (RE2 syntax), with the expression provided without any
+   * delimiters. If the field value doesn't match the regular expression, an
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not match regex pattern `^[a-zA-Z]//$`
+   * ```proto
+   * message MyString {
+   *   // value does not match regex pattern `^[a-zA-Z]//$`
    *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -567,17 +567,17 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object prefix_ = "";
   /**
    * <pre>
-   *`prefix` specifies that the field value must have the
+   * `prefix` specifies that the field value must have the
    *specified substring at the beginning of the string. If the field value
-   *doesn't start with the specified prefix, an error message will be
-   *generated.
+   * doesn't start with the specified prefix, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have prefix `pre`
+   * ```proto
+   * message MyString {
+   *   // value does not have prefix `pre`
    *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -589,17 +589,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`prefix` specifies that the field value must have the
+   * `prefix` specifies that the field value must have the
    *specified substring at the beginning of the string. If the field value
-   *doesn't start with the specified prefix, an error message will be
-   *generated.
+   * doesn't start with the specified prefix, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have prefix `pre`
+   * ```proto
+   * message MyString {
+   *   // value does not have prefix `pre`
    *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -620,17 +620,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`prefix` specifies that the field value must have the
+   * `prefix` specifies that the field value must have the
    *specified substring at the beginning of the string. If the field value
-   *doesn't start with the specified prefix, an error message will be
-   *generated.
+   * doesn't start with the specified prefix, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have prefix `pre`
+   * ```proto
+   * message MyString {
+   *   // value does not have prefix `pre`
    *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -656,16 +656,16 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object suffix_ = "";
   /**
    * <pre>
-   *`suffix` specifies that the field value must have the
+   * `suffix` specifies that the field value must have the
    *specified substring at the end of the string. If the field value doesn't
-   *end with the specified suffix, an error message will be generated.
+   * end with the specified suffix, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have suffix `post`
+   * ```proto
+   * message MyString {
+   *   // value does not have suffix `post`
    *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -677,16 +677,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`suffix` specifies that the field value must have the
+   * `suffix` specifies that the field value must have the
    *specified substring at the end of the string. If the field value doesn't
-   *end with the specified suffix, an error message will be generated.
+   * end with the specified suffix, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have suffix `post`
+   * ```proto
+   * message MyString {
+   *   // value does not have suffix `post`
    *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -707,16 +707,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`suffix` specifies that the field value must have the
+   * `suffix` specifies that the field value must have the
    *specified substring at the end of the string. If the field value doesn't
-   *end with the specified suffix, an error message will be generated.
+   * end with the specified suffix, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have suffix `post`
+   * ```proto
+   * message MyString {
+   *   // value does not have suffix `post`
    *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -742,16 +742,16 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object contains_ = "";
   /**
    * <pre>
-   *`contains` specifies that the field value must have the
+   * `contains` specifies that the field value must have the
    *specified substring anywhere in the string. If the field value doesn't
-   *contain the specified substring, an error message will be generated.
+   * contain the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not contain substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value does not contain substring `inside`.
    *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -763,16 +763,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`contains` specifies that the field value must have the
+   * `contains` specifies that the field value must have the
    *specified substring anywhere in the string. If the field value doesn't
-   *contain the specified substring, an error message will be generated.
+   * contain the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not contain substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value does not contain substring `inside`.
    *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -793,16 +793,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`contains` specifies that the field value must have the
+   * `contains` specifies that the field value must have the
    *specified substring anywhere in the string. If the field value doesn't
-   *contain the specified substring, an error message will be generated.
+   * contain the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not contain substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value does not contain substring `inside`.
    *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -828,16 +828,16 @@ private static final long serialVersionUID = 0L;
   private volatile java.lang.Object notContains_ = "";
   /**
    * <pre>
-   *`not_contains` specifies that the field value must not have the
+   * `not_contains` specifies that the field value must not have the
    *specified substring anywhere in the string. If the field value contains
-   *the specified substring, an error message will be generated.
+   * the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value contains substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value contains substring `inside`.
    *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -849,16 +849,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_contains` specifies that the field value must not have the
+   * `not_contains` specifies that the field value must not have the
    *specified substring anywhere in the string. If the field value contains
-   *the specified substring, an error message will be generated.
+   * the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value contains substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value contains substring `inside`.
    *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -879,16 +879,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_contains` specifies that the field value must not have the
+   * `not_contains` specifies that the field value must not have the
    *specified substring anywhere in the string. If the field value contains
-   *the specified substring, an error message will be generated.
+   * the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value contains substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value contains substring `inside`.
    *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -915,16 +915,16 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -936,16 +936,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -956,16 +956,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -977,16 +977,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1004,15 +1004,15 @@ private static final long serialVersionUID = 0L;
       com.google.protobuf.LazyStringArrayList.emptyList();
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1024,15 +1024,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1043,15 +1043,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1063,15 +1063,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1086,16 +1086,16 @@ private static final long serialVersionUID = 0L;
   public static final int EMAIL_FIELD_NUMBER = 12;
   /**
    * <pre>
-   *`email` specifies that the field value must be a valid email address
-   *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-   *If the field value isn't a valid email address, an error message will be generated.
+   * `email` specifies that the field value must be a valid email address
+   * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+   * If the field value isn't a valid email address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid email address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid email address
    *   string value = 1 [(buf.validate.field).string.email = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -1107,16 +1107,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`email` specifies that the field value must be a valid email address
-   *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-   *If the field value isn't a valid email address, an error message will be generated.
+   * `email` specifies that the field value must be a valid email address
+   * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+   * If the field value isn't a valid email address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid email address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid email address
    *   string value = 1 [(buf.validate.field).string.email = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -1133,17 +1133,17 @@ private static final long serialVersionUID = 0L;
   public static final int HOSTNAME_FIELD_NUMBER = 13;
   /**
    * <pre>
-   *`hostname` specifies that the field value must be a valid
-   *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-   *internationalized domain names (IDNs). If the field value isn't a
-   *valid hostname, an error message will be generated.
+   * `hostname` specifies that the field value must be a valid
+   * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+   * internationalized domain names (IDNs). If the field value isn't a
+   * valid hostname, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname
    *   string value = 1 [(buf.validate.field).string.hostname = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -1155,17 +1155,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`hostname` specifies that the field value must be a valid
-   *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-   *internationalized domain names (IDNs). If the field value isn't a
-   *valid hostname, an error message will be generated.
+   * `hostname` specifies that the field value must be a valid
+   * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+   * internationalized domain names (IDNs). If the field value isn't a
+   * valid hostname, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname
    *   string value = 1 [(buf.validate.field).string.hostname = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -1182,17 +1182,17 @@ private static final long serialVersionUID = 0L;
   public static final int IP_FIELD_NUMBER = 14;
   /**
    * <pre>
-   *`ip` specifies that the field value must be a valid IP
-   *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-   *If the field value isn't a valid IP address, an error message will be
-   *generated.
+   * `ip` specifies that the field value must be a valid IP
+   * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+   * If the field value isn't a valid IP address, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IP address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IP address
    *   string value = 1 [(buf.validate.field).string.ip = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -1204,17 +1204,17 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`ip` specifies that the field value must be a valid IP
-   *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-   *If the field value isn't a valid IP address, an error message will be
-   *generated.
+   * `ip` specifies that the field value must be a valid IP
+   * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+   * If the field value isn't a valid IP address, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IP address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IP address
    *   string value = 1 [(buf.validate.field).string.ip = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -1231,16 +1231,16 @@ private static final long serialVersionUID = 0L;
   public static final int IPV4_FIELD_NUMBER = 15;
   /**
    * <pre>
-   *`ipv4` specifies that the field value must be a valid IPv4
-   *address. If the field value isn't a valid IPv4 address, an error message
-   *will be generated.
+   * `ipv4` specifies that the field value must be a valid IPv4
+   * address. If the field value isn't a valid IPv4 address, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv4 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv4 address
    *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -1252,16 +1252,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`ipv4` specifies that the field value must be a valid IPv4
-   *address. If the field value isn't a valid IPv4 address, an error message
-   *will be generated.
+   * `ipv4` specifies that the field value must be a valid IPv4
+   * address. If the field value isn't a valid IPv4 address, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv4 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv4 address
    *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -1278,16 +1278,16 @@ private static final long serialVersionUID = 0L;
   public static final int IPV6_FIELD_NUMBER = 16;
   /**
    * <pre>
-   *`ipv6` specifies that the field value must be a valid
-   *IPv6 address, without surrounding square brackets. If the field value is
-   *not a valid IPv6 address, an error message will be generated.
+   * `ipv6` specifies that the field value must be a valid
+   * IPv6 address, without surrounding square brackets. If the field value is
+   * not a valid IPv6 address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv6 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv6 address
    *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -1299,16 +1299,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`ipv6` specifies that the field value must be a valid
-   *IPv6 address, without surrounding square brackets. If the field value is
-   *not a valid IPv6 address, an error message will be generated.
+   * `ipv6` specifies that the field value must be a valid
+   * IPv6 address, without surrounding square brackets. If the field value is
+   * not a valid IPv6 address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv6 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv6 address
    *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -1325,16 +1325,16 @@ private static final long serialVersionUID = 0L;
   public static final int URI_FIELD_NUMBER = 17;
   /**
    * <pre>
-   *`uri` specifies that the field value must be a valid,
-   *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-   *absolute URI, an error message will be generated.
+   * `uri` specifies that the field value must be a valid,
+   * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+   * absolute URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -1346,16 +1346,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`uri` specifies that the field value must be a valid,
-   *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-   *absolute URI, an error message will be generated.
+   * `uri` specifies that the field value must be a valid,
+   * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+   * absolute URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -1372,16 +1372,16 @@ private static final long serialVersionUID = 0L;
   public static final int URI_REF_FIELD_NUMBER = 18;
   /**
    * <pre>
-   *`uri_ref` specifies that the field value must be a valid URI
-   *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-   *field value isn't a valid URI, an error message will be generated.
+   * `uri_ref` specifies that the field value must be a valid URI
+   * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+   * field value isn't a valid URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -1393,16 +1393,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`uri_ref` specifies that the field value must be a valid URI
-   *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-   *field value isn't a valid URI, an error message will be generated.
+   * `uri_ref` specifies that the field value must be a valid URI
+   * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+   * field value isn't a valid URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -1419,18 +1419,18 @@ private static final long serialVersionUID = 0L;
   public static final int ADDRESS_FIELD_NUMBER = 21;
   /**
    * <pre>
-   *`address` specifies that the field value must be either a valid hostname
-   *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-   *(which doesn't support internationalized domain names or IDNs) or a valid
-   *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-   *message will be generated.
+   * `address` specifies that the field value must be either a valid hostname
+   * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+   * (which doesn't support internationalized domain names or IDNs) or a valid
+   * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname, or ip address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname, or ip address
    *   string value = 1 [(buf.validate.field).string.address = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -1442,18 +1442,18 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`address` specifies that the field value must be either a valid hostname
-   *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-   *(which doesn't support internationalized domain names or IDNs) or a valid
-   *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-   *message will be generated.
+   * `address` specifies that the field value must be either a valid hostname
+   * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+   * (which doesn't support internationalized domain names or IDNs) or a valid
+   * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname, or ip address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname, or ip address
    *   string value = 1 [(buf.validate.field).string.address = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -1470,16 +1470,16 @@ private static final long serialVersionUID = 0L;
   public static final int UUID_FIELD_NUMBER = 22;
   /**
    * <pre>
-   *`uuid` specifies that the field value must be a valid UUID as defined by
-   *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-   *field value isn't a valid UUID, an error message will be generated.
+   * `uuid` specifies that the field value must be a valid UUID as defined by
+   * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+   * field value isn't a valid UUID, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid UUID
+   * ```proto
+   * message MyString {
+   *   // value must be a valid UUID
    *   string value = 1 [(buf.validate.field).string.uuid = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -1491,16 +1491,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`uuid` specifies that the field value must be a valid UUID as defined by
-   *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-   *field value isn't a valid UUID, an error message will be generated.
+   * `uuid` specifies that the field value must be a valid UUID as defined by
+   * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+   * field value isn't a valid UUID, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid UUID
+   * ```proto
+   * message MyString {
+   *   // value must be a valid UUID
    *   string value = 1 [(buf.validate.field).string.uuid = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -1517,26 +1517,26 @@ private static final long serialVersionUID = 0L;
   public static final int WELL_KNOWN_REGEX_FIELD_NUMBER = 24;
   /**
    * <pre>
-   *`well_known_regex` specifies a common well-known pattern
-   *defined as a regex. If the field value doesn't match the well-known
-   *regex, an error message will be generated.
+   * `well_known_regex` specifies a common well-known pattern
+   * defined as a regex. If the field value doesn't match the well-known
+   * regex, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid HTTP header value
+   * ```proto
+   * message MyString {
+   *   // value must be a valid HTTP header value
    *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-   *}
-   *```
+   * }
+   * ```
    *
-   *#### KnownRegex
+   * #### KnownRegex
    *
-   *`well_known_regex` contains some well-known patterns.
+   * `well_known_regex` contains some well-known patterns.
    *
-   *| Name                          | Number | Description                               |
-   *|-------------------------------|--------|-------------------------------------------|
-   *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-   *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-   *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+   * | Name                          | Number | Description                               |
+   * |-------------------------------|--------|-------------------------------------------|
+   * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+   * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+   * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
    * </pre>
    *
    * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -1547,26 +1547,26 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`well_known_regex` specifies a common well-known pattern
-   *defined as a regex. If the field value doesn't match the well-known
-   *regex, an error message will be generated.
+   * `well_known_regex` specifies a common well-known pattern
+   * defined as a regex. If the field value doesn't match the well-known
+   * regex, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid HTTP header value
+   * ```proto
+   * message MyString {
+   *   // value must be a valid HTTP header value
    *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-   *}
-   *```
+   * }
+   * ```
    *
-   *#### KnownRegex
+   * #### KnownRegex
    *
-   *`well_known_regex` contains some well-known patterns.
+   * `well_known_regex` contains some well-known patterns.
    *
-   *| Name                          | Number | Description                               |
-   *|-------------------------------|--------|-------------------------------------------|
-   *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-   *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-   *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+   * | Name                          | Number | Description                               |
+   * |-------------------------------|--------|-------------------------------------------|
+   * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+   * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+   * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
    * </pre>
    *
    * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -1580,26 +1580,26 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`well_known_regex` specifies a common well-known pattern
-   *defined as a regex. If the field value doesn't match the well-known
-   *regex, an error message will be generated.
+   * `well_known_regex` specifies a common well-known pattern
+   * defined as a regex. If the field value doesn't match the well-known
+   * regex, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid HTTP header value
+   * ```proto
+   * message MyString {
+   *   // value must be a valid HTTP header value
    *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-   *}
-   *```
+   * }
+   * ```
    *
-   *#### KnownRegex
+   * #### KnownRegex
    *
-   *`well_known_regex` contains some well-known patterns.
+   * `well_known_regex` contains some well-known patterns.
    *
-   *| Name                          | Number | Description                               |
-   *|-------------------------------|--------|-------------------------------------------|
-   *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-   *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-   *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+   * | Name                          | Number | Description                               |
+   * |-------------------------------|--------|-------------------------------------------|
+   * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+   * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+   * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
    * </pre>
    *
    * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -1618,18 +1618,18 @@ private static final long serialVersionUID = 0L;
   private boolean strict_ = false;
   /**
    * <pre>
-   *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-   *enable strict header validation. By default, this is true, and HTTP header
-   *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-   *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-   *bypass header matching rules.
+   * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+   * enable strict header validation. By default, this is true, and HTTP header
+   * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+   * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+   * bypass header matching rules.
    *
-   *```proto
-   *message MyString {
+   * ```proto
+   * message MyString {
    *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
    *   string value = 1 [(buf.validate.field).string.strict = false];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool strict = 25 [json_name = "strict"];</code>
@@ -1641,18 +1641,18 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-   *enable strict header validation. By default, this is true, and HTTP header
-   *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-   *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-   *bypass header matching rules.
+   * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+   * enable strict header validation. By default, this is true, and HTTP header
+   * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+   * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+   * bypass header matching rules.
    *
-   *```proto
-   *message MyString {
+   * ```proto
+   * message MyString {
    *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
    *   string value = 1 [(buf.validate.field).string.strict = false];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool strict = 25 [json_name = "strict"];</code>
@@ -2748,15 +2748,15 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object const_ = "";
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
-     *the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified value. If
+     * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must equal `hello`
+     * ```proto
+     * message MyString {
+     *   // value must equal `hello`
      *   string value = 1 [(buf.validate.field).string.const = "hello"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -2767,15 +2767,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
-     *the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified value. If
+     * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must equal `hello`
+     * ```proto
+     * message MyString {
+     *   // value must equal `hello`
      *   string value = 1 [(buf.validate.field).string.const = "hello"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -2795,15 +2795,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
-     *the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified value. If
+     * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must equal `hello`
+     * ```proto
+     * message MyString {
+     *   // value must equal `hello`
      *   string value = 1 [(buf.validate.field).string.const = "hello"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -2824,15 +2824,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
-     *the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified value. If
+     * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must equal `hello`
+     * ```proto
+     * message MyString {
+     *   // value must equal `hello`
      *   string value = 1 [(buf.validate.field).string.const = "hello"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -2849,15 +2849,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
-     *the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified value. If
+     * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must equal `hello`
+     * ```proto
+     * message MyString {
+     *   // value must equal `hello`
      *   string value = 1 [(buf.validate.field).string.const = "hello"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -2871,15 +2871,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
-     *the field value doesn't match, an error message is generated.
+     * `const` requires the field value to exactly match the specified value. If
+     * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must equal `hello`
+     * ```proto
+     * message MyString {
+     *   // value must equal `hello`
      *   string value = 1 [(buf.validate.field).string.const = "hello"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -2899,17 +2899,17 @@ private static final long serialVersionUID = 0L;
     private long len_ ;
     /**
      * <pre>
-     *`len` dictates that the field value must have the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value does not meet the specified
-     *length, an error message will be generated.
+     * `len` dictates that the field value must have the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value does not meet the specified
+     * length, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 5 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be 5 characters
      *   string value = 1 [(buf.validate.field).string.len = 5];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -2921,17 +2921,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len` dictates that the field value must have the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value does not meet the specified
-     *length, an error message will be generated.
+     * `len` dictates that the field value must have the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value does not meet the specified
+     * length, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 5 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be 5 characters
      *   string value = 1 [(buf.validate.field).string.len = 5];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -2943,17 +2943,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len` dictates that the field value must have the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value does not meet the specified
-     *length, an error message will be generated.
+     * `len` dictates that the field value must have the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value does not meet the specified
+     * length, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 5 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be 5 characters
      *   string value = 1 [(buf.validate.field).string.len = 5];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -2969,17 +2969,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len` dictates that the field value must have the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value does not meet the specified
-     *length, an error message will be generated.
+     * `len` dictates that the field value must have the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value does not meet the specified
+     * length, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 5 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be 5 characters
      *   string value = 1 [(buf.validate.field).string.len = 5];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -2995,17 +2995,17 @@ private static final long serialVersionUID = 0L;
     private long minLen_ ;
     /**
      * <pre>
-     *`min_len` specifies that the field value must have at least the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value contains fewer characters, an error
-     *message will be generated.
+     * `min_len` specifies that the field value must have at least the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value contains fewer characters, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 3 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 3 characters
      *   string value = 1 [(buf.validate.field).string.min_len = 3];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3017,17 +3017,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_len` specifies that the field value must have at least the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value contains fewer characters, an error
-     *message will be generated.
+     * `min_len` specifies that the field value must have at least the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value contains fewer characters, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 3 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 3 characters
      *   string value = 1 [(buf.validate.field).string.min_len = 3];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3039,17 +3039,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_len` specifies that the field value must have at least the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value contains fewer characters, an error
-     *message will be generated.
+     * `min_len` specifies that the field value must have at least the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value contains fewer characters, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 3 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 3 characters
      *   string value = 1 [(buf.validate.field).string.min_len = 3];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3065,17 +3065,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_len` specifies that the field value must have at least the specified
-     *number of characters (Unicode code points), which may differ from the number
-     *of bytes in the string. If the field value contains fewer characters, an error
-     *message will be generated.
+     * `min_len` specifies that the field value must have at least the specified
+     * number of characters (Unicode code points), which may differ from the number
+     * of bytes in the string. If the field value contains fewer characters, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 3 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 3 characters
      *   string value = 1 [(buf.validate.field).string.min_len = 3];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3091,17 +3091,17 @@ private static final long serialVersionUID = 0L;
     private long maxLen_ ;
     /**
      * <pre>
-     *`max_len` specifies that the field value must have no more than the specified
-     *number of characters (Unicode code points), which may differ from the
-     *number of bytes in the string. If the field value contains more characters,
-     *an error message will be generated.
+     * `max_len` specifies that the field value must have no more than the specified
+     * number of characters (Unicode code points), which may differ from the
+     * number of bytes in the string. If the field value contains more characters,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 10 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 10 characters
      *   string value = 1 [(buf.validate.field).string.max_len = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3113,17 +3113,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_len` specifies that the field value must have no more than the specified
-     *number of characters (Unicode code points), which may differ from the
-     *number of bytes in the string. If the field value contains more characters,
-     *an error message will be generated.
+     * `max_len` specifies that the field value must have no more than the specified
+     * number of characters (Unicode code points), which may differ from the
+     * number of bytes in the string. If the field value contains more characters,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 10 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 10 characters
      *   string value = 1 [(buf.validate.field).string.max_len = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3135,17 +3135,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_len` specifies that the field value must have no more than the specified
-     *number of characters (Unicode code points), which may differ from the
-     *number of bytes in the string. If the field value contains more characters,
-     *an error message will be generated.
+     * `max_len` specifies that the field value must have no more than the specified
+     * number of characters (Unicode code points), which may differ from the
+     * number of bytes in the string. If the field value contains more characters,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 10 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 10 characters
      *   string value = 1 [(buf.validate.field).string.max_len = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3161,17 +3161,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_len` specifies that the field value must have no more than the specified
-     *number of characters (Unicode code points), which may differ from the
-     *number of bytes in the string. If the field value contains more characters,
-     *an error message will be generated.
+     * `max_len` specifies that the field value must have no more than the specified
+     * number of characters (Unicode code points), which may differ from the
+     * number of bytes in the string. If the field value contains more characters,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 10 characters
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 10 characters
      *   string value = 1 [(buf.validate.field).string.max_len = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -3187,16 +3187,16 @@ private static final long serialVersionUID = 0L;
     private long lenBytes_ ;
     /**
      * <pre>
-     *`len_bytes` dictates that the field value must have the specified number of
-     *bytes. If the field value does not match the specified length in bytes,
-     *an error message will be generated.
+     * `len_bytes` dictates that the field value must have the specified number of
+     * bytes. If the field value does not match the specified length in bytes,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 6 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be 6 bytes
      *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3208,16 +3208,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len_bytes` dictates that the field value must have the specified number of
-     *bytes. If the field value does not match the specified length in bytes,
-     *an error message will be generated.
+     * `len_bytes` dictates that the field value must have the specified number of
+     * bytes. If the field value does not match the specified length in bytes,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 6 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be 6 bytes
      *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3229,16 +3229,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len_bytes` dictates that the field value must have the specified number of
-     *bytes. If the field value does not match the specified length in bytes,
-     *an error message will be generated.
+     * `len_bytes` dictates that the field value must have the specified number of
+     * bytes. If the field value does not match the specified length in bytes,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 6 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be 6 bytes
      *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3254,16 +3254,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`len_bytes` dictates that the field value must have the specified number of
-     *bytes. If the field value does not match the specified length in bytes,
-     *an error message will be generated.
+     * `len_bytes` dictates that the field value must have the specified number of
+     * bytes. If the field value does not match the specified length in bytes,
+     * an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be 6 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be 6 bytes
      *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3279,17 +3279,17 @@ private static final long serialVersionUID = 0L;
     private long minBytes_ ;
     /**
      * <pre>
-     *`min_bytes` specifies that the field value must have at least the specified
-     *number of bytes. If the field value contains fewer bytes, an error message
-     *will be generated.
+     * `min_bytes` specifies that the field value must have at least the specified
+     * number of bytes. If the field value contains fewer bytes, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 4 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 4 bytes
      *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-     *}
+     * }
      *
-     *```
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3301,17 +3301,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_bytes` specifies that the field value must have at least the specified
-     *number of bytes. If the field value contains fewer bytes, an error message
-     *will be generated.
+     * `min_bytes` specifies that the field value must have at least the specified
+     * number of bytes. If the field value contains fewer bytes, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 4 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 4 bytes
      *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-     *}
+     * }
      *
-     *```
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3323,17 +3323,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_bytes` specifies that the field value must have at least the specified
-     *number of bytes. If the field value contains fewer bytes, an error message
-     *will be generated.
+     * `min_bytes` specifies that the field value must have at least the specified
+     * number of bytes. If the field value contains fewer bytes, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 4 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 4 bytes
      *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-     *}
+     * }
      *
-     *```
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3349,17 +3349,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`min_bytes` specifies that the field value must have at least the specified
-     *number of bytes. If the field value contains fewer bytes, an error message
-     *will be generated.
+     * `min_bytes` specifies that the field value must have at least the specified
+     * number of bytes. If the field value contains fewer bytes, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at least 4 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at least 4 bytes
      *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-     *}
+     * }
      *
-     *```
+     * ```
      * </pre>
      *
      * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3375,16 +3375,16 @@ private static final long serialVersionUID = 0L;
     private long maxBytes_ ;
     /**
      * <pre>
-     *`max_bytes` specifies that the field value must have no more than the
+     * `max_bytes` specifies that the field value must have no more than the
      *specified number of bytes. If the field value contains more bytes, an
-     *error message will be generated.
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 8 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 8 bytes
      *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3396,16 +3396,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_bytes` specifies that the field value must have no more than the
+     * `max_bytes` specifies that the field value must have no more than the
      *specified number of bytes. If the field value contains more bytes, an
-     *error message will be generated.
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 8 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 8 bytes
      *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3417,16 +3417,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_bytes` specifies that the field value must have no more than the
+     * `max_bytes` specifies that the field value must have no more than the
      *specified number of bytes. If the field value contains more bytes, an
-     *error message will be generated.
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 8 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 8 bytes
      *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3442,16 +3442,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`max_bytes` specifies that the field value must have no more than the
+     * `max_bytes` specifies that the field value must have no more than the
      *specified number of bytes. If the field value contains more bytes, an
-     *error message will be generated.
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value length must be at most 8 bytes
+     * ```proto
+     * message MyString {
+     *   // value length must be at most 8 bytes
      *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -3467,17 +3467,17 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object pattern_ = "";
     /**
      * <pre>
-     *`pattern` specifies that the field value must match the specified
-     *regular expression (RE2 syntax), with the expression provided without any
-     *delimiters. If the field value doesn't match the regular expression, an
-     *error message will be generated.
+     * `pattern` specifies that the field value must match the specified
+     * regular expression (RE2 syntax), with the expression provided without any
+     * delimiters. If the field value doesn't match the regular expression, an
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not match regex pattern `^[a-zA-Z]//$`
+     * ```proto
+     * message MyString {
+     *   // value does not match regex pattern `^[a-zA-Z]//$`
      *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -3488,17 +3488,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` specifies that the field value must match the specified
-     *regular expression (RE2 syntax), with the expression provided without any
-     *delimiters. If the field value doesn't match the regular expression, an
-     *error message will be generated.
+     * `pattern` specifies that the field value must match the specified
+     * regular expression (RE2 syntax), with the expression provided without any
+     * delimiters. If the field value doesn't match the regular expression, an
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not match regex pattern `^[a-zA-Z]//$`
+     * ```proto
+     * message MyString {
+     *   // value does not match regex pattern `^[a-zA-Z]//$`
      *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -3518,17 +3518,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` specifies that the field value must match the specified
-     *regular expression (RE2 syntax), with the expression provided without any
-     *delimiters. If the field value doesn't match the regular expression, an
-     *error message will be generated.
+     * `pattern` specifies that the field value must match the specified
+     * regular expression (RE2 syntax), with the expression provided without any
+     * delimiters. If the field value doesn't match the regular expression, an
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not match regex pattern `^[a-zA-Z]//$`
+     * ```proto
+     * message MyString {
+     *   // value does not match regex pattern `^[a-zA-Z]//$`
      *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -3549,17 +3549,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` specifies that the field value must match the specified
-     *regular expression (RE2 syntax), with the expression provided without any
-     *delimiters. If the field value doesn't match the regular expression, an
-     *error message will be generated.
+     * `pattern` specifies that the field value must match the specified
+     * regular expression (RE2 syntax), with the expression provided without any
+     * delimiters. If the field value doesn't match the regular expression, an
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not match regex pattern `^[a-zA-Z]//$`
+     * ```proto
+     * message MyString {
+     *   // value does not match regex pattern `^[a-zA-Z]//$`
      *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -3576,17 +3576,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` specifies that the field value must match the specified
-     *regular expression (RE2 syntax), with the expression provided without any
-     *delimiters. If the field value doesn't match the regular expression, an
-     *error message will be generated.
+     * `pattern` specifies that the field value must match the specified
+     * regular expression (RE2 syntax), with the expression provided without any
+     * delimiters. If the field value doesn't match the regular expression, an
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not match regex pattern `^[a-zA-Z]//$`
+     * ```proto
+     * message MyString {
+     *   // value does not match regex pattern `^[a-zA-Z]//$`
      *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -3600,17 +3600,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`pattern` specifies that the field value must match the specified
-     *regular expression (RE2 syntax), with the expression provided without any
-     *delimiters. If the field value doesn't match the regular expression, an
-     *error message will be generated.
+     * `pattern` specifies that the field value must match the specified
+     * regular expression (RE2 syntax), with the expression provided without any
+     * delimiters. If the field value doesn't match the regular expression, an
+     * error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not match regex pattern `^[a-zA-Z]//$`
+     * ```proto
+     * message MyString {
+     *   // value does not match regex pattern `^[a-zA-Z]//$`
      *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -3630,17 +3630,17 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object prefix_ = "";
     /**
      * <pre>
-     *`prefix` specifies that the field value must have the
+     * `prefix` specifies that the field value must have the
      *specified substring at the beginning of the string. If the field value
-     *doesn't start with the specified prefix, an error message will be
-     *generated.
+     * doesn't start with the specified prefix, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have prefix `pre`
+     * ```proto
+     * message MyString {
+     *   // value does not have prefix `pre`
      *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -3651,17 +3651,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` specifies that the field value must have the
+     * `prefix` specifies that the field value must have the
      *specified substring at the beginning of the string. If the field value
-     *doesn't start with the specified prefix, an error message will be
-     *generated.
+     * doesn't start with the specified prefix, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have prefix `pre`
+     * ```proto
+     * message MyString {
+     *   // value does not have prefix `pre`
      *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -3681,17 +3681,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` specifies that the field value must have the
+     * `prefix` specifies that the field value must have the
      *specified substring at the beginning of the string. If the field value
-     *doesn't start with the specified prefix, an error message will be
-     *generated.
+     * doesn't start with the specified prefix, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have prefix `pre`
+     * ```proto
+     * message MyString {
+     *   // value does not have prefix `pre`
      *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -3712,17 +3712,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` specifies that the field value must have the
+     * `prefix` specifies that the field value must have the
      *specified substring at the beginning of the string. If the field value
-     *doesn't start with the specified prefix, an error message will be
-     *generated.
+     * doesn't start with the specified prefix, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have prefix `pre`
+     * ```proto
+     * message MyString {
+     *   // value does not have prefix `pre`
      *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -3739,17 +3739,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` specifies that the field value must have the
+     * `prefix` specifies that the field value must have the
      *specified substring at the beginning of the string. If the field value
-     *doesn't start with the specified prefix, an error message will be
-     *generated.
+     * doesn't start with the specified prefix, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have prefix `pre`
+     * ```proto
+     * message MyString {
+     *   // value does not have prefix `pre`
      *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -3763,17 +3763,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`prefix` specifies that the field value must have the
+     * `prefix` specifies that the field value must have the
      *specified substring at the beginning of the string. If the field value
-     *doesn't start with the specified prefix, an error message will be
-     *generated.
+     * doesn't start with the specified prefix, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have prefix `pre`
+     * ```proto
+     * message MyString {
+     *   // value does not have prefix `pre`
      *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -3793,16 +3793,16 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object suffix_ = "";
     /**
      * <pre>
-     *`suffix` specifies that the field value must have the
+     * `suffix` specifies that the field value must have the
      *specified substring at the end of the string. If the field value doesn't
-     *end with the specified suffix, an error message will be generated.
+     * end with the specified suffix, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have suffix `post`
+     * ```proto
+     * message MyString {
+     *   // value does not have suffix `post`
      *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -3813,16 +3813,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` specifies that the field value must have the
+     * `suffix` specifies that the field value must have the
      *specified substring at the end of the string. If the field value doesn't
-     *end with the specified suffix, an error message will be generated.
+     * end with the specified suffix, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have suffix `post`
+     * ```proto
+     * message MyString {
+     *   // value does not have suffix `post`
      *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -3842,16 +3842,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` specifies that the field value must have the
+     * `suffix` specifies that the field value must have the
      *specified substring at the end of the string. If the field value doesn't
-     *end with the specified suffix, an error message will be generated.
+     * end with the specified suffix, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have suffix `post`
+     * ```proto
+     * message MyString {
+     *   // value does not have suffix `post`
      *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -3872,16 +3872,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` specifies that the field value must have the
+     * `suffix` specifies that the field value must have the
      *specified substring at the end of the string. If the field value doesn't
-     *end with the specified suffix, an error message will be generated.
+     * end with the specified suffix, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have suffix `post`
+     * ```proto
+     * message MyString {
+     *   // value does not have suffix `post`
      *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -3898,16 +3898,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` specifies that the field value must have the
+     * `suffix` specifies that the field value must have the
      *specified substring at the end of the string. If the field value doesn't
-     *end with the specified suffix, an error message will be generated.
+     * end with the specified suffix, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have suffix `post`
+     * ```proto
+     * message MyString {
+     *   // value does not have suffix `post`
      *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -3921,16 +3921,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`suffix` specifies that the field value must have the
+     * `suffix` specifies that the field value must have the
      *specified substring at the end of the string. If the field value doesn't
-     *end with the specified suffix, an error message will be generated.
+     * end with the specified suffix, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not have suffix `post`
+     * ```proto
+     * message MyString {
+     *   // value does not have suffix `post`
      *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -3950,16 +3950,16 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object contains_ = "";
     /**
      * <pre>
-     *`contains` specifies that the field value must have the
+     * `contains` specifies that the field value must have the
      *specified substring anywhere in the string. If the field value doesn't
-     *contain the specified substring, an error message will be generated.
+     * contain the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not contain substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value does not contain substring `inside`.
      *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -3970,16 +3970,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` specifies that the field value must have the
+     * `contains` specifies that the field value must have the
      *specified substring anywhere in the string. If the field value doesn't
-     *contain the specified substring, an error message will be generated.
+     * contain the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not contain substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value does not contain substring `inside`.
      *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -3999,16 +3999,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` specifies that the field value must have the
+     * `contains` specifies that the field value must have the
      *specified substring anywhere in the string. If the field value doesn't
-     *contain the specified substring, an error message will be generated.
+     * contain the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not contain substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value does not contain substring `inside`.
      *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -4029,16 +4029,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` specifies that the field value must have the
+     * `contains` specifies that the field value must have the
      *specified substring anywhere in the string. If the field value doesn't
-     *contain the specified substring, an error message will be generated.
+     * contain the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not contain substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value does not contain substring `inside`.
      *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -4055,16 +4055,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` specifies that the field value must have the
+     * `contains` specifies that the field value must have the
      *specified substring anywhere in the string. If the field value doesn't
-     *contain the specified substring, an error message will be generated.
+     * contain the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not contain substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value does not contain substring `inside`.
      *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -4078,16 +4078,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`contains` specifies that the field value must have the
+     * `contains` specifies that the field value must have the
      *specified substring anywhere in the string. If the field value doesn't
-     *contain the specified substring, an error message will be generated.
+     * contain the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value does not contain substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value does not contain substring `inside`.
      *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -4107,16 +4107,16 @@ private static final long serialVersionUID = 0L;
     private java.lang.Object notContains_ = "";
     /**
      * <pre>
-     *`not_contains` specifies that the field value must not have the
+     * `not_contains` specifies that the field value must not have the
      *specified substring anywhere in the string. If the field value contains
-     *the specified substring, an error message will be generated.
+     * the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value contains substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value contains substring `inside`.
      *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -4127,16 +4127,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_contains` specifies that the field value must not have the
+     * `not_contains` specifies that the field value must not have the
      *specified substring anywhere in the string. If the field value contains
-     *the specified substring, an error message will be generated.
+     * the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value contains substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value contains substring `inside`.
      *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -4156,16 +4156,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_contains` specifies that the field value must not have the
+     * `not_contains` specifies that the field value must not have the
      *specified substring anywhere in the string. If the field value contains
-     *the specified substring, an error message will be generated.
+     * the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value contains substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value contains substring `inside`.
      *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -4186,16 +4186,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_contains` specifies that the field value must not have the
+     * `not_contains` specifies that the field value must not have the
      *specified substring anywhere in the string. If the field value contains
-     *the specified substring, an error message will be generated.
+     * the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value contains substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value contains substring `inside`.
      *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -4212,16 +4212,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_contains` specifies that the field value must not have the
+     * `not_contains` specifies that the field value must not have the
      *specified substring anywhere in the string. If the field value contains
-     *the specified substring, an error message will be generated.
+     * the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value contains substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value contains substring `inside`.
      *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -4235,16 +4235,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_contains` specifies that the field value must not have the
+     * `not_contains` specifies that the field value must not have the
      *specified substring anywhere in the string. If the field value contains
-     *the specified substring, an error message will be generated.
+     * the specified substring, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value contains substring `inside`.
+     * ```proto
+     * message MyString {
+     *   // value contains substring `inside`.
      *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -4271,16 +4271,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4293,16 +4293,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4313,16 +4313,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4334,16 +4334,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4356,16 +4356,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4384,16 +4384,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4411,16 +4411,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4438,16 +4438,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4462,16 +4462,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` specifies that the field value must be equal to one of the specified
-     *values. If the field value isn't one of the specified values, an error
-     *message will be generated.
+     * `in` specifies that the field value must be equal to one of the specified
+     * values. If the field value isn't one of the specified values, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be in list ["apple", "banana"]
-     *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-     *}
-     *```
+     * ```proto
+     * message MyString {
+     *   // value must be in list ["apple", "banana"]
+     *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -4499,15 +4499,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4520,15 +4520,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4539,15 +4539,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4559,15 +4559,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4580,15 +4580,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4607,15 +4607,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4633,15 +4633,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4659,15 +4659,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4682,15 +4682,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` specifies that the field value cannot be equal to any
-     *of the specified values. If the field value is one of the specified values,
-     *an error message will be generated.
-     *```proto
-     *message MyString {
-     *  // value must not be in list ["orange", "grape"]
-     *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-     *}
-     *```
+     * `not_in` specifies that the field value cannot be equal to any
+     * of the specified values. If the field value is one of the specified values,
+     * an error message will be generated.
+     * ```proto
+     * message MyString {
+     *   // value must not be in list ["orange", "grape"]
+     *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -4710,16 +4710,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`email` specifies that the field value must be a valid email address
-     *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-     *If the field value isn't a valid email address, an error message will be generated.
+     * `email` specifies that the field value must be a valid email address
+     * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+     * If the field value isn't a valid email address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid email address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid email address
      *   string value = 1 [(buf.validate.field).string.email = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -4730,16 +4730,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`email` specifies that the field value must be a valid email address
-     *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-     *If the field value isn't a valid email address, an error message will be generated.
+     * `email` specifies that the field value must be a valid email address
+     * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+     * If the field value isn't a valid email address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid email address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid email address
      *   string value = 1 [(buf.validate.field).string.email = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -4753,16 +4753,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`email` specifies that the field value must be a valid email address
-     *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-     *If the field value isn't a valid email address, an error message will be generated.
+     * `email` specifies that the field value must be a valid email address
+     * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+     * If the field value isn't a valid email address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid email address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid email address
      *   string value = 1 [(buf.validate.field).string.email = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -4778,16 +4778,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`email` specifies that the field value must be a valid email address
-     *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-     *If the field value isn't a valid email address, an error message will be generated.
+     * `email` specifies that the field value must be a valid email address
+     * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+     * If the field value isn't a valid email address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid email address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid email address
      *   string value = 1 [(buf.validate.field).string.email = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -4804,17 +4804,17 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`hostname` specifies that the field value must be a valid
-     *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-     *internationalized domain names (IDNs). If the field value isn't a
-     *valid hostname, an error message will be generated.
+     * `hostname` specifies that the field value must be a valid
+     * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+     * internationalized domain names (IDNs). If the field value isn't a
+     * valid hostname, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname
      *   string value = 1 [(buf.validate.field).string.hostname = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -4825,17 +4825,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`hostname` specifies that the field value must be a valid
-     *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-     *internationalized domain names (IDNs). If the field value isn't a
-     *valid hostname, an error message will be generated.
+     * `hostname` specifies that the field value must be a valid
+     * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+     * internationalized domain names (IDNs). If the field value isn't a
+     * valid hostname, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname
      *   string value = 1 [(buf.validate.field).string.hostname = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -4849,17 +4849,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`hostname` specifies that the field value must be a valid
-     *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-     *internationalized domain names (IDNs). If the field value isn't a
-     *valid hostname, an error message will be generated.
+     * `hostname` specifies that the field value must be a valid
+     * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+     * internationalized domain names (IDNs). If the field value isn't a
+     * valid hostname, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname
      *   string value = 1 [(buf.validate.field).string.hostname = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -4875,17 +4875,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`hostname` specifies that the field value must be a valid
-     *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-     *internationalized domain names (IDNs). If the field value isn't a
-     *valid hostname, an error message will be generated.
+     * `hostname` specifies that the field value must be a valid
+     * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+     * internationalized domain names (IDNs). If the field value isn't a
+     * valid hostname, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname
      *   string value = 1 [(buf.validate.field).string.hostname = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -4902,17 +4902,17 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`ip` specifies that the field value must be a valid IP
-     *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-     *If the field value isn't a valid IP address, an error message will be
-     *generated.
+     * `ip` specifies that the field value must be a valid IP
+     * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+     * If the field value isn't a valid IP address, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IP address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IP address
      *   string value = 1 [(buf.validate.field).string.ip = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -4923,17 +4923,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ip` specifies that the field value must be a valid IP
-     *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-     *If the field value isn't a valid IP address, an error message will be
-     *generated.
+     * `ip` specifies that the field value must be a valid IP
+     * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+     * If the field value isn't a valid IP address, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IP address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IP address
      *   string value = 1 [(buf.validate.field).string.ip = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -4947,17 +4947,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ip` specifies that the field value must be a valid IP
-     *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-     *If the field value isn't a valid IP address, an error message will be
-     *generated.
+     * `ip` specifies that the field value must be a valid IP
+     * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+     * If the field value isn't a valid IP address, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IP address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IP address
      *   string value = 1 [(buf.validate.field).string.ip = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -4973,17 +4973,17 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ip` specifies that the field value must be a valid IP
-     *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-     *If the field value isn't a valid IP address, an error message will be
-     *generated.
+     * `ip` specifies that the field value must be a valid IP
+     * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+     * If the field value isn't a valid IP address, an error message will be
+     * generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IP address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IP address
      *   string value = 1 [(buf.validate.field).string.ip = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -5000,16 +5000,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`ipv4` specifies that the field value must be a valid IPv4
-     *address. If the field value isn't a valid IPv4 address, an error message
-     *will be generated.
+     * `ipv4` specifies that the field value must be a valid IPv4
+     * address. If the field value isn't a valid IPv4 address, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv4 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv4 address
      *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -5020,16 +5020,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv4` specifies that the field value must be a valid IPv4
-     *address. If the field value isn't a valid IPv4 address, an error message
-     *will be generated.
+     * `ipv4` specifies that the field value must be a valid IPv4
+     * address. If the field value isn't a valid IPv4 address, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv4 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv4 address
      *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -5043,16 +5043,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv4` specifies that the field value must be a valid IPv4
-     *address. If the field value isn't a valid IPv4 address, an error message
-     *will be generated.
+     * `ipv4` specifies that the field value must be a valid IPv4
+     * address. If the field value isn't a valid IPv4 address, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv4 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv4 address
      *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -5068,16 +5068,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv4` specifies that the field value must be a valid IPv4
-     *address. If the field value isn't a valid IPv4 address, an error message
-     *will be generated.
+     * `ipv4` specifies that the field value must be a valid IPv4
+     * address. If the field value isn't a valid IPv4 address, an error message
+     * will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv4 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv4 address
      *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -5094,16 +5094,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`ipv6` specifies that the field value must be a valid
-     *IPv6 address, without surrounding square brackets. If the field value is
-     *not a valid IPv6 address, an error message will be generated.
+     * `ipv6` specifies that the field value must be a valid
+     * IPv6 address, without surrounding square brackets. If the field value is
+     * not a valid IPv6 address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv6 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv6 address
      *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -5114,16 +5114,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv6` specifies that the field value must be a valid
-     *IPv6 address, without surrounding square brackets. If the field value is
-     *not a valid IPv6 address, an error message will be generated.
+     * `ipv6` specifies that the field value must be a valid
+     * IPv6 address, without surrounding square brackets. If the field value is
+     * not a valid IPv6 address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv6 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv6 address
      *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -5137,16 +5137,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv6` specifies that the field value must be a valid
-     *IPv6 address, without surrounding square brackets. If the field value is
-     *not a valid IPv6 address, an error message will be generated.
+     * `ipv6` specifies that the field value must be a valid
+     * IPv6 address, without surrounding square brackets. If the field value is
+     * not a valid IPv6 address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv6 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv6 address
      *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -5162,16 +5162,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`ipv6` specifies that the field value must be a valid
-     *IPv6 address, without surrounding square brackets. If the field value is
-     *not a valid IPv6 address, an error message will be generated.
+     * `ipv6` specifies that the field value must be a valid
+     * IPv6 address, without surrounding square brackets. If the field value is
+     * not a valid IPv6 address, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid IPv6 address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid IPv6 address
      *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -5188,16 +5188,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`uri` specifies that the field value must be a valid,
-     *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-     *absolute URI, an error message will be generated.
+     * `uri` specifies that the field value must be a valid,
+     * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+     * absolute URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -5208,16 +5208,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uri` specifies that the field value must be a valid,
-     *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-     *absolute URI, an error message will be generated.
+     * `uri` specifies that the field value must be a valid,
+     * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+     * absolute URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -5231,16 +5231,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uri` specifies that the field value must be a valid,
-     *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-     *absolute URI, an error message will be generated.
+     * `uri` specifies that the field value must be a valid,
+     * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+     * absolute URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -5256,16 +5256,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uri` specifies that the field value must be a valid,
-     *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-     *absolute URI, an error message will be generated.
+     * `uri` specifies that the field value must be a valid,
+     * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+     * absolute URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -5282,16 +5282,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`uri_ref` specifies that the field value must be a valid URI
-     *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-     *field value isn't a valid URI, an error message will be generated.
+     * `uri_ref` specifies that the field value must be a valid URI
+     * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+     * field value isn't a valid URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -5302,16 +5302,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uri_ref` specifies that the field value must be a valid URI
-     *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-     *field value isn't a valid URI, an error message will be generated.
+     * `uri_ref` specifies that the field value must be a valid URI
+     * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+     * field value isn't a valid URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -5325,16 +5325,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uri_ref` specifies that the field value must be a valid URI
-     *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-     *field value isn't a valid URI, an error message will be generated.
+     * `uri_ref` specifies that the field value must be a valid URI
+     * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+     * field value isn't a valid URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -5350,16 +5350,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uri_ref` specifies that the field value must be a valid URI
-     *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-     *field value isn't a valid URI, an error message will be generated.
+     * `uri_ref` specifies that the field value must be a valid URI
+     * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+     * field value isn't a valid URI, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid URI
+     * ```proto
+     * message MyString {
+     *   // value must be a valid URI
      *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -5376,18 +5376,18 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`address` specifies that the field value must be either a valid hostname
-     *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-     *(which doesn't support internationalized domain names or IDNs) or a valid
-     *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-     *message will be generated.
+     * `address` specifies that the field value must be either a valid hostname
+     * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+     * (which doesn't support internationalized domain names or IDNs) or a valid
+     * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname, or ip address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname, or ip address
      *   string value = 1 [(buf.validate.field).string.address = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -5398,18 +5398,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`address` specifies that the field value must be either a valid hostname
-     *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-     *(which doesn't support internationalized domain names or IDNs) or a valid
-     *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-     *message will be generated.
+     * `address` specifies that the field value must be either a valid hostname
+     * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+     * (which doesn't support internationalized domain names or IDNs) or a valid
+     * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname, or ip address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname, or ip address
      *   string value = 1 [(buf.validate.field).string.address = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -5423,18 +5423,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`address` specifies that the field value must be either a valid hostname
-     *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-     *(which doesn't support internationalized domain names or IDNs) or a valid
-     *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-     *message will be generated.
+     * `address` specifies that the field value must be either a valid hostname
+     * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+     * (which doesn't support internationalized domain names or IDNs) or a valid
+     * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname, or ip address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname, or ip address
      *   string value = 1 [(buf.validate.field).string.address = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -5450,18 +5450,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`address` specifies that the field value must be either a valid hostname
-     *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-     *(which doesn't support internationalized domain names or IDNs) or a valid
-     *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-     *message will be generated.
+     * `address` specifies that the field value must be either a valid hostname
+     * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+     * (which doesn't support internationalized domain names or IDNs) or a valid
+     * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+     * message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid hostname, or ip address
+     * ```proto
+     * message MyString {
+     *   // value must be a valid hostname, or ip address
      *   string value = 1 [(buf.validate.field).string.address = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -5478,16 +5478,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`uuid` specifies that the field value must be a valid UUID as defined by
-     *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-     *field value isn't a valid UUID, an error message will be generated.
+     * `uuid` specifies that the field value must be a valid UUID as defined by
+     * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+     * field value isn't a valid UUID, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid UUID
+     * ```proto
+     * message MyString {
+     *   // value must be a valid UUID
      *   string value = 1 [(buf.validate.field).string.uuid = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -5498,16 +5498,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uuid` specifies that the field value must be a valid UUID as defined by
-     *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-     *field value isn't a valid UUID, an error message will be generated.
+     * `uuid` specifies that the field value must be a valid UUID as defined by
+     * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+     * field value isn't a valid UUID, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid UUID
+     * ```proto
+     * message MyString {
+     *   // value must be a valid UUID
      *   string value = 1 [(buf.validate.field).string.uuid = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -5521,16 +5521,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uuid` specifies that the field value must be a valid UUID as defined by
-     *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-     *field value isn't a valid UUID, an error message will be generated.
+     * `uuid` specifies that the field value must be a valid UUID as defined by
+     * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+     * field value isn't a valid UUID, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid UUID
+     * ```proto
+     * message MyString {
+     *   // value must be a valid UUID
      *   string value = 1 [(buf.validate.field).string.uuid = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -5546,16 +5546,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`uuid` specifies that the field value must be a valid UUID as defined by
-     *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-     *field value isn't a valid UUID, an error message will be generated.
+     * `uuid` specifies that the field value must be a valid UUID as defined by
+     * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+     * field value isn't a valid UUID, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid UUID
+     * ```proto
+     * message MyString {
+     *   // value must be a valid UUID
      *   string value = 1 [(buf.validate.field).string.uuid = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -5572,26 +5572,26 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`well_known_regex` specifies a common well-known pattern
-     *defined as a regex. If the field value doesn't match the well-known
-     *regex, an error message will be generated.
+     * `well_known_regex` specifies a common well-known pattern
+     * defined as a regex. If the field value doesn't match the well-known
+     * regex, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid HTTP header value
+     * ```proto
+     * message MyString {
+     *   // value must be a valid HTTP header value
      *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-     *}
-     *```
+     * }
+     * ```
      *
-     *#### KnownRegex
+     * #### KnownRegex
      *
-     *`well_known_regex` contains some well-known patterns.
+     * `well_known_regex` contains some well-known patterns.
      *
-     *| Name                          | Number | Description                               |
-     *|-------------------------------|--------|-------------------------------------------|
-     *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-     *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-     *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+     * | Name                          | Number | Description                               |
+     * |-------------------------------|--------|-------------------------------------------|
+     * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+     * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+     * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
      * </pre>
      *
      * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -5603,26 +5603,26 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`well_known_regex` specifies a common well-known pattern
-     *defined as a regex. If the field value doesn't match the well-known
-     *regex, an error message will be generated.
+     * `well_known_regex` specifies a common well-known pattern
+     * defined as a regex. If the field value doesn't match the well-known
+     * regex, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid HTTP header value
+     * ```proto
+     * message MyString {
+     *   // value must be a valid HTTP header value
      *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-     *}
-     *```
+     * }
+     * ```
      *
-     *#### KnownRegex
+     * #### KnownRegex
      *
-     *`well_known_regex` contains some well-known patterns.
+     * `well_known_regex` contains some well-known patterns.
      *
-     *| Name                          | Number | Description                               |
-     *|-------------------------------|--------|-------------------------------------------|
-     *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-     *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-     *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+     * | Name                          | Number | Description                               |
+     * |-------------------------------|--------|-------------------------------------------|
+     * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+     * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+     * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
      * </pre>
      *
      * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -5637,26 +5637,26 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`well_known_regex` specifies a common well-known pattern
-     *defined as a regex. If the field value doesn't match the well-known
-     *regex, an error message will be generated.
+     * `well_known_regex` specifies a common well-known pattern
+     * defined as a regex. If the field value doesn't match the well-known
+     * regex, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid HTTP header value
+     * ```proto
+     * message MyString {
+     *   // value must be a valid HTTP header value
      *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-     *}
-     *```
+     * }
+     * ```
      *
-     *#### KnownRegex
+     * #### KnownRegex
      *
-     *`well_known_regex` contains some well-known patterns.
+     * `well_known_regex` contains some well-known patterns.
      *
-     *| Name                          | Number | Description                               |
-     *|-------------------------------|--------|-------------------------------------------|
-     *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-     *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-     *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+     * | Name                          | Number | Description                               |
+     * |-------------------------------|--------|-------------------------------------------|
+     * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+     * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+     * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
      * </pre>
      *
      * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -5671,26 +5671,26 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`well_known_regex` specifies a common well-known pattern
-     *defined as a regex. If the field value doesn't match the well-known
-     *regex, an error message will be generated.
+     * `well_known_regex` specifies a common well-known pattern
+     * defined as a regex. If the field value doesn't match the well-known
+     * regex, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid HTTP header value
+     * ```proto
+     * message MyString {
+     *   // value must be a valid HTTP header value
      *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-     *}
-     *```
+     * }
+     * ```
      *
-     *#### KnownRegex
+     * #### KnownRegex
      *
-     *`well_known_regex` contains some well-known patterns.
+     * `well_known_regex` contains some well-known patterns.
      *
-     *| Name                          | Number | Description                               |
-     *|-------------------------------|--------|-------------------------------------------|
-     *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-     *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-     *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+     * | Name                          | Number | Description                               |
+     * |-------------------------------|--------|-------------------------------------------|
+     * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+     * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+     * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
      * </pre>
      *
      * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -5707,26 +5707,26 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`well_known_regex` specifies a common well-known pattern
-     *defined as a regex. If the field value doesn't match the well-known
-     *regex, an error message will be generated.
+     * `well_known_regex` specifies a common well-known pattern
+     * defined as a regex. If the field value doesn't match the well-known
+     * regex, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid HTTP header value
+     * ```proto
+     * message MyString {
+     *   // value must be a valid HTTP header value
      *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-     *}
-     *```
+     * }
+     * ```
      *
-     *#### KnownRegex
+     * #### KnownRegex
      *
-     *`well_known_regex` contains some well-known patterns.
+     * `well_known_regex` contains some well-known patterns.
      *
-     *| Name                          | Number | Description                               |
-     *|-------------------------------|--------|-------------------------------------------|
-     *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-     *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-     *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+     * | Name                          | Number | Description                               |
+     * |-------------------------------|--------|-------------------------------------------|
+     * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+     * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+     * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
      * </pre>
      *
      * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -5744,26 +5744,26 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`well_known_regex` specifies a common well-known pattern
-     *defined as a regex. If the field value doesn't match the well-known
-     *regex, an error message will be generated.
+     * `well_known_regex` specifies a common well-known pattern
+     * defined as a regex. If the field value doesn't match the well-known
+     * regex, an error message will be generated.
      *
-     *```proto
-     *message MyString {
-     *  // value must be a valid HTTP header value
+     * ```proto
+     * message MyString {
+     *   // value must be a valid HTTP header value
      *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-     *}
-     *```
+     * }
+     * ```
      *
-     *#### KnownRegex
+     * #### KnownRegex
      *
-     *`well_known_regex` contains some well-known patterns.
+     * `well_known_regex` contains some well-known patterns.
      *
-     *| Name                          | Number | Description                               |
-     *|-------------------------------|--------|-------------------------------------------|
-     *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-     *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-     *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+     * | Name                          | Number | Description                               |
+     * |-------------------------------|--------|-------------------------------------------|
+     * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+     * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+     * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
      * </pre>
      *
      * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -5781,18 +5781,18 @@ private static final long serialVersionUID = 0L;
     private boolean strict_ ;
     /**
      * <pre>
-     *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-     *enable strict header validation. By default, this is true, and HTTP header
-     *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-     *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-     *bypass header matching rules.
+     * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+     * enable strict header validation. By default, this is true, and HTTP header
+     * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+     * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+     * bypass header matching rules.
      *
-     *```proto
-     *message MyString {
+     * ```proto
+     * message MyString {
      *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
      *   string value = 1 [(buf.validate.field).string.strict = false];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool strict = 25 [json_name = "strict"];</code>
@@ -5804,18 +5804,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-     *enable strict header validation. By default, this is true, and HTTP header
-     *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-     *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-     *bypass header matching rules.
+     * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+     * enable strict header validation. By default, this is true, and HTTP header
+     * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+     * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+     * bypass header matching rules.
      *
-     *```proto
-     *message MyString {
+     * ```proto
+     * message MyString {
      *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
      *   string value = 1 [(buf.validate.field).string.strict = false];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool strict = 25 [json_name = "strict"];</code>
@@ -5827,18 +5827,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-     *enable strict header validation. By default, this is true, and HTTP header
-     *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-     *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-     *bypass header matching rules.
+     * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+     * enable strict header validation. By default, this is true, and HTTP header
+     * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+     * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+     * bypass header matching rules.
      *
-     *```proto
-     *message MyString {
+     * ```proto
+     * message MyString {
      *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
      *   string value = 1 [(buf.validate.field).string.strict = false];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool strict = 25 [json_name = "strict"];</code>
@@ -5854,18 +5854,18 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-     *enable strict header validation. By default, this is true, and HTTP header
-     *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-     *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-     *bypass header matching rules.
+     * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+     * enable strict header validation. By default, this is true, and HTTP header
+     * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+     * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+     * bypass header matching rules.
      *
-     *```proto
-     *message MyString {
+     * ```proto
+     * message MyString {
      *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
      *   string value = 1 [(buf.validate.field).string.strict = false];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional bool strict = 25 [json_name = "strict"];</code>

--- a/src/main/java/build/buf/validate/StringRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/StringRulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
-   *the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified value. If
+   * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must equal `hello`
+   * ```proto
+   * message MyString {
+   *   // value must equal `hello`
    *   string value = 1 [(buf.validate.field).string.const = "hello"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface StringRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
-   *the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified value. If
+   * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must equal `hello`
+   * ```proto
+   * message MyString {
+   *   // value must equal `hello`
    *   string value = 1 [(buf.validate.field).string.const = "hello"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -43,15 +43,15 @@ public interface StringRulesOrBuilder extends
   java.lang.String getConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
-   *the field value doesn't match, an error message is generated.
+   * `const` requires the field value to exactly match the specified value. If
+   * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must equal `hello`
+   * ```proto
+   * message MyString {
+   *   // value must equal `hello`
    *   string value = 1 [(buf.validate.field).string.const = "hello"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -62,17 +62,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`len` dictates that the field value must have the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value does not meet the specified
-   *length, an error message will be generated.
+   * `len` dictates that the field value must have the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value does not meet the specified
+   * length, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 5 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be 5 characters
    *   string value = 1 [(buf.validate.field).string.len = 5];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -81,17 +81,17 @@ public interface StringRulesOrBuilder extends
   boolean hasLen();
   /**
    * <pre>
-   *`len` dictates that the field value must have the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value does not meet the specified
-   *length, an error message will be generated.
+   * `len` dictates that the field value must have the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value does not meet the specified
+   * length, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 5 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be 5 characters
    *   string value = 1 [(buf.validate.field).string.len = 5];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len = 19 [json_name = "len", (.buf.validate.priv.field) = { ... }</code>
@@ -101,17 +101,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`min_len` specifies that the field value must have at least the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value contains fewer characters, an error
-   *message will be generated.
+   * `min_len` specifies that the field value must have at least the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value contains fewer characters, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 3 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 3 characters
    *   string value = 1 [(buf.validate.field).string.min_len = 3];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -120,17 +120,17 @@ public interface StringRulesOrBuilder extends
   boolean hasMinLen();
   /**
    * <pre>
-   *`min_len` specifies that the field value must have at least the specified
-   *number of characters (Unicode code points), which may differ from the number
-   *of bytes in the string. If the field value contains fewer characters, an error
-   *message will be generated.
+   * `min_len` specifies that the field value must have at least the specified
+   * number of characters (Unicode code points), which may differ from the number
+   * of bytes in the string. If the field value contains fewer characters, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 3 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 3 characters
    *   string value = 1 [(buf.validate.field).string.min_len = 3];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_len = 2 [json_name = "minLen", (.buf.validate.priv.field) = { ... }</code>
@@ -140,17 +140,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`max_len` specifies that the field value must have no more than the specified
-   *number of characters (Unicode code points), which may differ from the
-   *number of bytes in the string. If the field value contains more characters,
-   *an error message will be generated.
+   * `max_len` specifies that the field value must have no more than the specified
+   * number of characters (Unicode code points), which may differ from the
+   * number of bytes in the string. If the field value contains more characters,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 10 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 10 characters
    *   string value = 1 [(buf.validate.field).string.max_len = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -159,17 +159,17 @@ public interface StringRulesOrBuilder extends
   boolean hasMaxLen();
   /**
    * <pre>
-   *`max_len` specifies that the field value must have no more than the specified
-   *number of characters (Unicode code points), which may differ from the
-   *number of bytes in the string. If the field value contains more characters,
-   *an error message will be generated.
+   * `max_len` specifies that the field value must have no more than the specified
+   * number of characters (Unicode code points), which may differ from the
+   * number of bytes in the string. If the field value contains more characters,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 10 characters
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 10 characters
    *   string value = 1 [(buf.validate.field).string.max_len = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_len = 3 [json_name = "maxLen", (.buf.validate.priv.field) = { ... }</code>
@@ -179,16 +179,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`len_bytes` dictates that the field value must have the specified number of
-   *bytes. If the field value does not match the specified length in bytes,
-   *an error message will be generated.
+   * `len_bytes` dictates that the field value must have the specified number of
+   * bytes. If the field value does not match the specified length in bytes,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 6 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be 6 bytes
    *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -197,16 +197,16 @@ public interface StringRulesOrBuilder extends
   boolean hasLenBytes();
   /**
    * <pre>
-   *`len_bytes` dictates that the field value must have the specified number of
-   *bytes. If the field value does not match the specified length in bytes,
-   *an error message will be generated.
+   * `len_bytes` dictates that the field value must have the specified number of
+   * bytes. If the field value does not match the specified length in bytes,
+   * an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be 6 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be 6 bytes
    *   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 len_bytes = 20 [json_name = "lenBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -216,17 +216,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`min_bytes` specifies that the field value must have at least the specified
-   *number of bytes. If the field value contains fewer bytes, an error message
-   *will be generated.
+   * `min_bytes` specifies that the field value must have at least the specified
+   * number of bytes. If the field value contains fewer bytes, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 4 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 4 bytes
    *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-   *}
+   * }
    *
-   *```
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -235,17 +235,17 @@ public interface StringRulesOrBuilder extends
   boolean hasMinBytes();
   /**
    * <pre>
-   *`min_bytes` specifies that the field value must have at least the specified
-   *number of bytes. If the field value contains fewer bytes, an error message
-   *will be generated.
+   * `min_bytes` specifies that the field value must have at least the specified
+   * number of bytes. If the field value contains fewer bytes, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at least 4 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at least 4 bytes
    *   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-   *}
+   * }
    *
-   *```
+   * ```
    * </pre>
    *
    * <code>optional uint64 min_bytes = 4 [json_name = "minBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -255,16 +255,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`max_bytes` specifies that the field value must have no more than the
+   * `max_bytes` specifies that the field value must have no more than the
    *specified number of bytes. If the field value contains more bytes, an
-   *error message will be generated.
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 8 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 8 bytes
    *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -273,16 +273,16 @@ public interface StringRulesOrBuilder extends
   boolean hasMaxBytes();
   /**
    * <pre>
-   *`max_bytes` specifies that the field value must have no more than the
+   * `max_bytes` specifies that the field value must have no more than the
    *specified number of bytes. If the field value contains more bytes, an
-   *error message will be generated.
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value length must be at most 8 bytes
+   * ```proto
+   * message MyString {
+   *   // value length must be at most 8 bytes
    *   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 max_bytes = 5 [json_name = "maxBytes", (.buf.validate.priv.field) = { ... }</code>
@@ -292,17 +292,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`pattern` specifies that the field value must match the specified
-   *regular expression (RE2 syntax), with the expression provided without any
-   *delimiters. If the field value doesn't match the regular expression, an
-   *error message will be generated.
+   * `pattern` specifies that the field value must match the specified
+   * regular expression (RE2 syntax), with the expression provided without any
+   * delimiters. If the field value doesn't match the regular expression, an
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not match regex pattern `^[a-zA-Z]//$`
+   * ```proto
+   * message MyString {
+   *   // value does not match regex pattern `^[a-zA-Z]//$`
    *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -311,17 +311,17 @@ public interface StringRulesOrBuilder extends
   boolean hasPattern();
   /**
    * <pre>
-   *`pattern` specifies that the field value must match the specified
-   *regular expression (RE2 syntax), with the expression provided without any
-   *delimiters. If the field value doesn't match the regular expression, an
-   *error message will be generated.
+   * `pattern` specifies that the field value must match the specified
+   * regular expression (RE2 syntax), with the expression provided without any
+   * delimiters. If the field value doesn't match the regular expression, an
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not match regex pattern `^[a-zA-Z]//$`
+   * ```proto
+   * message MyString {
+   *   // value does not match regex pattern `^[a-zA-Z]//$`
    *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -330,17 +330,17 @@ public interface StringRulesOrBuilder extends
   java.lang.String getPattern();
   /**
    * <pre>
-   *`pattern` specifies that the field value must match the specified
-   *regular expression (RE2 syntax), with the expression provided without any
-   *delimiters. If the field value doesn't match the regular expression, an
-   *error message will be generated.
+   * `pattern` specifies that the field value must match the specified
+   * regular expression (RE2 syntax), with the expression provided without any
+   * delimiters. If the field value doesn't match the regular expression, an
+   * error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not match regex pattern `^[a-zA-Z]//$`
+   * ```proto
+   * message MyString {
+   *   // value does not match regex pattern `^[a-zA-Z]//$`
    *   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string pattern = 6 [json_name = "pattern", (.buf.validate.priv.field) = { ... }</code>
@@ -351,17 +351,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`prefix` specifies that the field value must have the
+   * `prefix` specifies that the field value must have the
    *specified substring at the beginning of the string. If the field value
-   *doesn't start with the specified prefix, an error message will be
-   *generated.
+   * doesn't start with the specified prefix, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have prefix `pre`
+   * ```proto
+   * message MyString {
+   *   // value does not have prefix `pre`
    *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -370,17 +370,17 @@ public interface StringRulesOrBuilder extends
   boolean hasPrefix();
   /**
    * <pre>
-   *`prefix` specifies that the field value must have the
+   * `prefix` specifies that the field value must have the
    *specified substring at the beginning of the string. If the field value
-   *doesn't start with the specified prefix, an error message will be
-   *generated.
+   * doesn't start with the specified prefix, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have prefix `pre`
+   * ```proto
+   * message MyString {
+   *   // value does not have prefix `pre`
    *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -389,17 +389,17 @@ public interface StringRulesOrBuilder extends
   java.lang.String getPrefix();
   /**
    * <pre>
-   *`prefix` specifies that the field value must have the
+   * `prefix` specifies that the field value must have the
    *specified substring at the beginning of the string. If the field value
-   *doesn't start with the specified prefix, an error message will be
-   *generated.
+   * doesn't start with the specified prefix, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have prefix `pre`
+   * ```proto
+   * message MyString {
+   *   // value does not have prefix `pre`
    *   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string prefix = 7 [json_name = "prefix", (.buf.validate.priv.field) = { ... }</code>
@@ -410,16 +410,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`suffix` specifies that the field value must have the
+   * `suffix` specifies that the field value must have the
    *specified substring at the end of the string. If the field value doesn't
-   *end with the specified suffix, an error message will be generated.
+   * end with the specified suffix, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have suffix `post`
+   * ```proto
+   * message MyString {
+   *   // value does not have suffix `post`
    *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -428,16 +428,16 @@ public interface StringRulesOrBuilder extends
   boolean hasSuffix();
   /**
    * <pre>
-   *`suffix` specifies that the field value must have the
+   * `suffix` specifies that the field value must have the
    *specified substring at the end of the string. If the field value doesn't
-   *end with the specified suffix, an error message will be generated.
+   * end with the specified suffix, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have suffix `post`
+   * ```proto
+   * message MyString {
+   *   // value does not have suffix `post`
    *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -446,16 +446,16 @@ public interface StringRulesOrBuilder extends
   java.lang.String getSuffix();
   /**
    * <pre>
-   *`suffix` specifies that the field value must have the
+   * `suffix` specifies that the field value must have the
    *specified substring at the end of the string. If the field value doesn't
-   *end with the specified suffix, an error message will be generated.
+   * end with the specified suffix, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not have suffix `post`
+   * ```proto
+   * message MyString {
+   *   // value does not have suffix `post`
    *   string value = 1 [(buf.validate.field).string.suffix = "post"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string suffix = 8 [json_name = "suffix", (.buf.validate.priv.field) = { ... }</code>
@@ -466,16 +466,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`contains` specifies that the field value must have the
+   * `contains` specifies that the field value must have the
    *specified substring anywhere in the string. If the field value doesn't
-   *contain the specified substring, an error message will be generated.
+   * contain the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not contain substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value does not contain substring `inside`.
    *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -484,16 +484,16 @@ public interface StringRulesOrBuilder extends
   boolean hasContains();
   /**
    * <pre>
-   *`contains` specifies that the field value must have the
+   * `contains` specifies that the field value must have the
    *specified substring anywhere in the string. If the field value doesn't
-   *contain the specified substring, an error message will be generated.
+   * contain the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not contain substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value does not contain substring `inside`.
    *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -502,16 +502,16 @@ public interface StringRulesOrBuilder extends
   java.lang.String getContains();
   /**
    * <pre>
-   *`contains` specifies that the field value must have the
+   * `contains` specifies that the field value must have the
    *specified substring anywhere in the string. If the field value doesn't
-   *contain the specified substring, an error message will be generated.
+   * contain the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value does not contain substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value does not contain substring `inside`.
    *   string value = 1 [(buf.validate.field).string.contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string contains = 9 [json_name = "contains", (.buf.validate.priv.field) = { ... }</code>
@@ -522,16 +522,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_contains` specifies that the field value must not have the
+   * `not_contains` specifies that the field value must not have the
    *specified substring anywhere in the string. If the field value contains
-   *the specified substring, an error message will be generated.
+   * the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value contains substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value contains substring `inside`.
    *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -540,16 +540,16 @@ public interface StringRulesOrBuilder extends
   boolean hasNotContains();
   /**
    * <pre>
-   *`not_contains` specifies that the field value must not have the
+   * `not_contains` specifies that the field value must not have the
    *specified substring anywhere in the string. If the field value contains
-   *the specified substring, an error message will be generated.
+   * the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value contains substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value contains substring `inside`.
    *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -558,16 +558,16 @@ public interface StringRulesOrBuilder extends
   java.lang.String getNotContains();
   /**
    * <pre>
-   *`not_contains` specifies that the field value must not have the
+   * `not_contains` specifies that the field value must not have the
    *specified substring anywhere in the string. If the field value contains
-   *the specified substring, an error message will be generated.
+   * the specified substring, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value contains substring `inside`.
+   * ```proto
+   * message MyString {
+   *   // value contains substring `inside`.
    *   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional string not_contains = 23 [json_name = "notContains", (.buf.validate.priv.field) = { ... }</code>
@@ -578,16 +578,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -597,16 +597,16 @@ public interface StringRulesOrBuilder extends
       getInList();
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -615,16 +615,16 @@ public interface StringRulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -634,16 +634,16 @@ public interface StringRulesOrBuilder extends
   java.lang.String getIn(int index);
   /**
    * <pre>
-   *`in` specifies that the field value must be equal to one of the specified
-   *values. If the field value isn't one of the specified values, an error
-   *message will be generated.
+   * `in` specifies that the field value must be equal to one of the specified
+   * values. If the field value isn't one of the specified values, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be in list ["apple", "banana"]
-   *  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-   *}
-   *```
+   * ```proto
+   * message MyString {
+   *   // value must be in list ["apple", "banana"]
+   *   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string in = 10 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -655,15 +655,15 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -673,15 +673,15 @@ public interface StringRulesOrBuilder extends
       getNotInList();
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -690,15 +690,15 @@ public interface StringRulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -708,15 +708,15 @@ public interface StringRulesOrBuilder extends
   java.lang.String getNotIn(int index);
   /**
    * <pre>
-   *`not_in` specifies that the field value cannot be equal to any
-   *of the specified values. If the field value is one of the specified values,
-   *an error message will be generated.
-   *```proto
-   *message MyString {
-   *  // value must not be in list ["orange", "grape"]
-   *  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-   *}
-   *```
+   * `not_in` specifies that the field value cannot be equal to any
+   * of the specified values. If the field value is one of the specified values,
+   * an error message will be generated.
+   * ```proto
+   * message MyString {
+   *   // value must not be in list ["orange", "grape"]
+   *   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated string not_in = 11 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -728,16 +728,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`email` specifies that the field value must be a valid email address
-   *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-   *If the field value isn't a valid email address, an error message will be generated.
+   * `email` specifies that the field value must be a valid email address
+   * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+   * If the field value isn't a valid email address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid email address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid email address
    *   string value = 1 [(buf.validate.field).string.email = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -746,16 +746,16 @@ public interface StringRulesOrBuilder extends
   boolean hasEmail();
   /**
    * <pre>
-   *`email` specifies that the field value must be a valid email address
-   *(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-   *If the field value isn't a valid email address, an error message will be generated.
+   * `email` specifies that the field value must be a valid email address
+   * (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+   * If the field value isn't a valid email address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid email address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid email address
    *   string value = 1 [(buf.validate.field).string.email = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool email = 12 [json_name = "email", (.buf.validate.priv.field) = { ... }</code>
@@ -765,17 +765,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`hostname` specifies that the field value must be a valid
-   *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-   *internationalized domain names (IDNs). If the field value isn't a
-   *valid hostname, an error message will be generated.
+   * `hostname` specifies that the field value must be a valid
+   * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+   * internationalized domain names (IDNs). If the field value isn't a
+   * valid hostname, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname
    *   string value = 1 [(buf.validate.field).string.hostname = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -784,17 +784,17 @@ public interface StringRulesOrBuilder extends
   boolean hasHostname();
   /**
    * <pre>
-   *`hostname` specifies that the field value must be a valid
-   *hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-   *internationalized domain names (IDNs). If the field value isn't a
-   *valid hostname, an error message will be generated.
+   * `hostname` specifies that the field value must be a valid
+   * hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+   * internationalized domain names (IDNs). If the field value isn't a
+   * valid hostname, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname
    *   string value = 1 [(buf.validate.field).string.hostname = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool hostname = 13 [json_name = "hostname", (.buf.validate.priv.field) = { ... }</code>
@@ -804,17 +804,17 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`ip` specifies that the field value must be a valid IP
-   *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-   *If the field value isn't a valid IP address, an error message will be
-   *generated.
+   * `ip` specifies that the field value must be a valid IP
+   * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+   * If the field value isn't a valid IP address, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IP address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IP address
    *   string value = 1 [(buf.validate.field).string.ip = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -823,17 +823,17 @@ public interface StringRulesOrBuilder extends
   boolean hasIp();
   /**
    * <pre>
-   *`ip` specifies that the field value must be a valid IP
-   *(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-   *If the field value isn't a valid IP address, an error message will be
-   *generated.
+   * `ip` specifies that the field value must be a valid IP
+   * (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+   * If the field value isn't a valid IP address, an error message will be
+   * generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IP address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IP address
    *   string value = 1 [(buf.validate.field).string.ip = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ip = 14 [json_name = "ip", (.buf.validate.priv.field) = { ... }</code>
@@ -843,16 +843,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`ipv4` specifies that the field value must be a valid IPv4
-   *address. If the field value isn't a valid IPv4 address, an error message
-   *will be generated.
+   * `ipv4` specifies that the field value must be a valid IPv4
+   * address. If the field value isn't a valid IPv4 address, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv4 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv4 address
    *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -861,16 +861,16 @@ public interface StringRulesOrBuilder extends
   boolean hasIpv4();
   /**
    * <pre>
-   *`ipv4` specifies that the field value must be a valid IPv4
-   *address. If the field value isn't a valid IPv4 address, an error message
-   *will be generated.
+   * `ipv4` specifies that the field value must be a valid IPv4
+   * address. If the field value isn't a valid IPv4 address, an error message
+   * will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv4 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv4 address
    *   string value = 1 [(buf.validate.field).string.ipv4 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv4 = 15 [json_name = "ipv4", (.buf.validate.priv.field) = { ... }</code>
@@ -880,16 +880,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`ipv6` specifies that the field value must be a valid
-   *IPv6 address, without surrounding square brackets. If the field value is
-   *not a valid IPv6 address, an error message will be generated.
+   * `ipv6` specifies that the field value must be a valid
+   * IPv6 address, without surrounding square brackets. If the field value is
+   * not a valid IPv6 address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv6 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv6 address
    *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -898,16 +898,16 @@ public interface StringRulesOrBuilder extends
   boolean hasIpv6();
   /**
    * <pre>
-   *`ipv6` specifies that the field value must be a valid
-   *IPv6 address, without surrounding square brackets. If the field value is
-   *not a valid IPv6 address, an error message will be generated.
+   * `ipv6` specifies that the field value must be a valid
+   * IPv6 address, without surrounding square brackets. If the field value is
+   * not a valid IPv6 address, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid IPv6 address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid IPv6 address
    *   string value = 1 [(buf.validate.field).string.ipv6 = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool ipv6 = 16 [json_name = "ipv6", (.buf.validate.priv.field) = { ... }</code>
@@ -917,16 +917,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`uri` specifies that the field value must be a valid,
-   *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-   *absolute URI, an error message will be generated.
+   * `uri` specifies that the field value must be a valid,
+   * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+   * absolute URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -935,16 +935,16 @@ public interface StringRulesOrBuilder extends
   boolean hasUri();
   /**
    * <pre>
-   *`uri` specifies that the field value must be a valid,
-   *absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-   *absolute URI, an error message will be generated.
+   * `uri` specifies that the field value must be a valid,
+   * absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+   * absolute URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri = 17 [json_name = "uri", (.buf.validate.priv.field) = { ... }</code>
@@ -954,16 +954,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`uri_ref` specifies that the field value must be a valid URI
-   *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-   *field value isn't a valid URI, an error message will be generated.
+   * `uri_ref` specifies that the field value must be a valid URI
+   * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+   * field value isn't a valid URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -972,16 +972,16 @@ public interface StringRulesOrBuilder extends
   boolean hasUriRef();
   /**
    * <pre>
-   *`uri_ref` specifies that the field value must be a valid URI
-   *as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-   *field value isn't a valid URI, an error message will be generated.
+   * `uri_ref` specifies that the field value must be a valid URI
+   * as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+   * field value isn't a valid URI, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid URI
+   * ```proto
+   * message MyString {
+   *   // value must be a valid URI
    *   string value = 1 [(buf.validate.field).string.uri_ref = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uri_ref = 18 [json_name = "uriRef", (.buf.validate.priv.field) = { ... }</code>
@@ -991,18 +991,18 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`address` specifies that the field value must be either a valid hostname
-   *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-   *(which doesn't support internationalized domain names or IDNs) or a valid
-   *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-   *message will be generated.
+   * `address` specifies that the field value must be either a valid hostname
+   * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+   * (which doesn't support internationalized domain names or IDNs) or a valid
+   * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname, or ip address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname, or ip address
    *   string value = 1 [(buf.validate.field).string.address = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -1011,18 +1011,18 @@ public interface StringRulesOrBuilder extends
   boolean hasAddress();
   /**
    * <pre>
-   *`address` specifies that the field value must be either a valid hostname
-   *as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-   *(which doesn't support internationalized domain names or IDNs) or a valid
-   *IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-   *message will be generated.
+   * `address` specifies that the field value must be either a valid hostname
+   * as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+   * (which doesn't support internationalized domain names or IDNs) or a valid
+   * IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+   * message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid hostname, or ip address
+   * ```proto
+   * message MyString {
+   *   // value must be a valid hostname, or ip address
    *   string value = 1 [(buf.validate.field).string.address = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool address = 21 [json_name = "address", (.buf.validate.priv.field) = { ... }</code>
@@ -1032,16 +1032,16 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`uuid` specifies that the field value must be a valid UUID as defined by
-   *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-   *field value isn't a valid UUID, an error message will be generated.
+   * `uuid` specifies that the field value must be a valid UUID as defined by
+   * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+   * field value isn't a valid UUID, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid UUID
+   * ```proto
+   * message MyString {
+   *   // value must be a valid UUID
    *   string value = 1 [(buf.validate.field).string.uuid = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -1050,16 +1050,16 @@ public interface StringRulesOrBuilder extends
   boolean hasUuid();
   /**
    * <pre>
-   *`uuid` specifies that the field value must be a valid UUID as defined by
-   *[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-   *field value isn't a valid UUID, an error message will be generated.
+   * `uuid` specifies that the field value must be a valid UUID as defined by
+   * [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+   * field value isn't a valid UUID, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid UUID
+   * ```proto
+   * message MyString {
+   *   // value must be a valid UUID
    *   string value = 1 [(buf.validate.field).string.uuid = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool uuid = 22 [json_name = "uuid", (.buf.validate.priv.field) = { ... }</code>
@@ -1069,26 +1069,26 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *`well_known_regex` specifies a common well-known pattern
-   *defined as a regex. If the field value doesn't match the well-known
-   *regex, an error message will be generated.
+   * `well_known_regex` specifies a common well-known pattern
+   * defined as a regex. If the field value doesn't match the well-known
+   * regex, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid HTTP header value
+   * ```proto
+   * message MyString {
+   *   // value must be a valid HTTP header value
    *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-   *}
-   *```
+   * }
+   * ```
    *
-   *#### KnownRegex
+   * #### KnownRegex
    *
-   *`well_known_regex` contains some well-known patterns.
+   * `well_known_regex` contains some well-known patterns.
    *
-   *| Name                          | Number | Description                               |
-   *|-------------------------------|--------|-------------------------------------------|
-   *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-   *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-   *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+   * | Name                          | Number | Description                               |
+   * |-------------------------------|--------|-------------------------------------------|
+   * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+   * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+   * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
    * </pre>
    *
    * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -1097,26 +1097,26 @@ public interface StringRulesOrBuilder extends
   boolean hasWellKnownRegex();
   /**
    * <pre>
-   *`well_known_regex` specifies a common well-known pattern
-   *defined as a regex. If the field value doesn't match the well-known
-   *regex, an error message will be generated.
+   * `well_known_regex` specifies a common well-known pattern
+   * defined as a regex. If the field value doesn't match the well-known
+   * regex, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid HTTP header value
+   * ```proto
+   * message MyString {
+   *   // value must be a valid HTTP header value
    *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-   *}
-   *```
+   * }
+   * ```
    *
-   *#### KnownRegex
+   * #### KnownRegex
    *
-   *`well_known_regex` contains some well-known patterns.
+   * `well_known_regex` contains some well-known patterns.
    *
-   *| Name                          | Number | Description                               |
-   *|-------------------------------|--------|-------------------------------------------|
-   *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-   *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-   *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+   * | Name                          | Number | Description                               |
+   * |-------------------------------|--------|-------------------------------------------|
+   * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+   * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+   * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
    * </pre>
    *
    * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -1125,26 +1125,26 @@ public interface StringRulesOrBuilder extends
   int getWellKnownRegexValue();
   /**
    * <pre>
-   *`well_known_regex` specifies a common well-known pattern
-   *defined as a regex. If the field value doesn't match the well-known
-   *regex, an error message will be generated.
+   * `well_known_regex` specifies a common well-known pattern
+   * defined as a regex. If the field value doesn't match the well-known
+   * regex, an error message will be generated.
    *
-   *```proto
-   *message MyString {
-   *  // value must be a valid HTTP header value
+   * ```proto
+   * message MyString {
+   *   // value must be a valid HTTP header value
    *   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-   *}
-   *```
+   * }
+   * ```
    *
-   *#### KnownRegex
+   * #### KnownRegex
    *
-   *`well_known_regex` contains some well-known patterns.
+   * `well_known_regex` contains some well-known patterns.
    *
-   *| Name                          | Number | Description                               |
-   *|-------------------------------|--------|-------------------------------------------|
-   *| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-   *| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-   *| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+   * | Name                          | Number | Description                               |
+   * |-------------------------------|--------|-------------------------------------------|
+   * | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+   * | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+   * | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
    * </pre>
    *
    * <code>.buf.validate.KnownRegex well_known_regex = 24 [json_name = "wellKnownRegex", (.buf.validate.priv.field) = { ... }</code>
@@ -1154,18 +1154,18 @@ public interface StringRulesOrBuilder extends
 
   /**
    * <pre>
-   *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-   *enable strict header validation. By default, this is true, and HTTP header
-   *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-   *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-   *bypass header matching rules.
+   * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+   * enable strict header validation. By default, this is true, and HTTP header
+   * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+   * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+   * bypass header matching rules.
    *
-   *```proto
-   *message MyString {
+   * ```proto
+   * message MyString {
    *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
    *   string value = 1 [(buf.validate.field).string.strict = false];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool strict = 25 [json_name = "strict"];</code>
@@ -1174,18 +1174,18 @@ public interface StringRulesOrBuilder extends
   boolean hasStrict();
   /**
    * <pre>
-   *This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-   *enable strict header validation. By default, this is true, and HTTP header
-   *validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-   *validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
-   *bypass header matching rules.
+   * This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+   * enable strict header validation. By default, this is true, and HTTP header
+   * validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+   * validations that only disallow `&#92;r&#92;n&#92;0` characters, which can be used to
+   * bypass header matching rules.
    *
-   *```proto
-   *message MyString {
+   * ```proto
+   * message MyString {
    *   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
    *   string value = 1 [(buf.validate.field).string.strict = false];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional bool strict = 25 [json_name = "strict"];</code>

--- a/src/main/java/build/buf/validate/TimestampRules.java
+++ b/src/main/java/build/buf/validate/TimestampRules.java
@@ -135,14 +135,14 @@ private static final long serialVersionUID = 0L;
   private com.google.protobuf.Timestamp const_;
   /**
    * <pre>
-   *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+   * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must equal 2023-05-03T10:00:00Z
+   * ```proto
+   * message MyTimestamp {
+   *   // value must equal 2023-05-03T10:00:00Z
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,14 +154,14 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+   * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must equal 2023-05-03T10:00:00Z
+   * ```proto
+   * message MyTimestamp {
+   *   // value must equal 2023-05-03T10:00:00Z
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -173,14 +173,14 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+   * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must equal 2023-05-03T10:00:00Z
+   * ```proto
+   * message MyTimestamp {
+   *   // value must equal 2023-05-03T10:00:00Z
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -321,14 +321,14 @@ private static final long serialVersionUID = 0L;
   public static final int LT_NOW_FIELD_NUMBER = 7;
   /**
    * <pre>
-   *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+   * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
+   * ```proto
+   * message MyTimestamp {
    *  // value must be less than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -340,14 +340,14 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+   * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
+   * ```proto
+   * message MyTimestamp {
    *  // value must be less than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -364,24 +364,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gt` requires the timestamp field value to be greater than the specified
+   * `gt` requires the timestamp field value to be greater than the specified
    * value (exclusive). If the value of `gt` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -393,24 +393,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the timestamp field value to be greater than the specified
+   * `gt` requires the timestamp field value to be greater than the specified
    * value (exclusive). If the value of `gt` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -425,24 +425,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the timestamp field value to be greater than the specified
+   * `gt` requires the timestamp field value to be greater than the specified
    * value (exclusive). If the value of `gt` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -458,24 +458,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 6;
   /**
    * <pre>
-   *`gte` requires the timestamp field value to be greater than or equal to the
+   * `gte` requires the timestamp field value to be greater than or equal to the
    * specified value (exclusive). If the value of `gte` is larger than a
    * specified `lt` or `lte`, the range is reversed, and the field value
    * must be outside the specified range. If the field value doesn't meet
    * the required conditions, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -487,24 +487,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the timestamp field value to be greater than or equal to the
+   * `gte` requires the timestamp field value to be greater than or equal to the
    * specified value (exclusive). If the value of `gte` is larger than a
    * specified `lt` or `lte`, the range is reversed, and the field value
    * must be outside the specified range. If the field value doesn't meet
    * the required conditions, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -519,24 +519,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the timestamp field value to be greater than or equal to the
+   * `gte` requires the timestamp field value to be greater than or equal to the
    * specified value (exclusive). If the value of `gte` is larger than a
    * specified `lt` or `lte`, the range is reversed, and the field value
    * must be outside the specified range. If the field value doesn't meet
    * the required conditions, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -552,14 +552,14 @@ private static final long serialVersionUID = 0L;
   public static final int GT_NOW_FIELD_NUMBER = 8;
   /**
    * <pre>
-   *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+   * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be greater than now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be greater than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -571,14 +571,14 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+   * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be greater than now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be greater than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -598,12 +598,12 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be within 1 hour of now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be within 1 hour of now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -617,12 +617,12 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be within 1 hour of now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be within 1 hour of now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -636,12 +636,12 @@ private static final long serialVersionUID = 0L;
    * <pre>
    * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be within 1 hour of now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be within 1 hour of now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -1301,14 +1301,14 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> constBuilder_;
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1319,14 +1319,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1341,14 +1341,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1368,14 +1368,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1393,14 +1393,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1425,14 +1425,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1449,14 +1449,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1468,14 +1468,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1490,14 +1490,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+     * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must equal 2023-05-03T10:00:00Z
+     * ```proto
+     * message MyTimestamp {
+     *   // value must equal 2023-05-03T10:00:00Z
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -2000,14 +2000,14 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+     * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
+     * ```proto
+     * message MyTimestamp {
      *  // value must be less than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2018,14 +2018,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+     * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
+     * ```proto
+     * message MyTimestamp {
      *  // value must be less than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2039,14 +2039,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+     * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
+     * ```proto
+     * message MyTimestamp {
      *  // value must be less than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2062,14 +2062,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+     * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
+     * ```proto
+     * message MyTimestamp {
      *  // value must be less than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2088,24 +2088,24 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> gtBuilder_;
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2117,24 +2117,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2156,24 +2156,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2193,24 +2193,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2228,24 +2228,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2272,24 +2272,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2312,24 +2312,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2339,24 +2339,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2374,24 +2374,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the timestamp field value to be greater than the specified
+     * `gt` requires the timestamp field value to be greater than the specified
      * value (exclusive). If the value of `gt` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -2419,24 +2419,24 @@ private static final long serialVersionUID = 0L;
         com.google.protobuf.Timestamp, com.google.protobuf.Timestamp.Builder, com.google.protobuf.TimestampOrBuilder> gteBuilder_;
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2448,24 +2448,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2487,24 +2487,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2524,24 +2524,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2559,24 +2559,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2603,24 +2603,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2643,24 +2643,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2670,24 +2670,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2705,24 +2705,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the timestamp field value to be greater than or equal to the
+     * `gte` requires the timestamp field value to be greater than or equal to the
      * specified value (exclusive). If the value of `gte` is larger than a
      * specified `lt` or `lte`, the range is reversed, and the field value
      * must be outside the specified range. If the field value doesn't meet
      * the required conditions, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-     *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+     * ```proto
+     * message MyTimestamp {
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+     *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-     *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+     *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+     *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
      *
-     *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-     *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-     *}
-     *```
+     *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+     *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+     * }
+     * ```
      * </pre>
      *
      * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -2748,14 +2748,14 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+     * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be greater than now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be greater than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2766,14 +2766,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+     * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be greater than now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be greater than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2787,14 +2787,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+     * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be greater than now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be greater than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2810,14 +2810,14 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+     * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be greater than now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be greater than now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -2839,12 +2839,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -2857,12 +2857,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -2879,12 +2879,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -2906,12 +2906,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -2931,12 +2931,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -2963,12 +2963,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -2987,12 +2987,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -3006,12 +3006,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -3028,12 +3028,12 @@ private static final long serialVersionUID = 0L;
      * <pre>
      * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
      *
-     *```proto
-     *message MyTimestamp {
-     *  // value must be within 1 hour of now
+     * ```proto
+     * message MyTimestamp {
+     *   // value must be within 1 hour of now
      *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/TimestampRulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/TimestampRulesOrBuilder.java
@@ -9,14 +9,14 @@ public interface TimestampRulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+   * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must equal 2023-05-03T10:00:00Z
+   * ```proto
+   * message MyTimestamp {
+   *   // value must equal 2023-05-03T10:00:00Z
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -25,14 +25,14 @@ public interface TimestampRulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+   * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must equal 2023-05-03T10:00:00Z
+   * ```proto
+   * message MyTimestamp {
+   *   // value must equal 2023-05-03T10:00:00Z
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -41,14 +41,14 @@ public interface TimestampRulesOrBuilder extends
   com.google.protobuf.Timestamp getConst();
   /**
    * <pre>
-   *`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+   * `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must equal 2023-05-03T10:00:00Z
+   * ```proto
+   * message MyTimestamp {
+   *   // value must equal 2023-05-03T10:00:00Z
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Timestamp const = 2 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -153,14 +153,14 @@ public interface TimestampRulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+   * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
+   * ```proto
+   * message MyTimestamp {
    *  // value must be less than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -169,14 +169,14 @@ public interface TimestampRulesOrBuilder extends
   boolean hasLtNow();
   /**
    * <pre>
-   *`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+   * `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
+   * ```proto
+   * message MyTimestamp {
    *  // value must be less than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool lt_now = 7 [json_name = "ltNow", (.buf.validate.priv.field) = { ... }</code>
@@ -186,24 +186,24 @@ public interface TimestampRulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the timestamp field value to be greater than the specified
+   * `gt` requires the timestamp field value to be greater than the specified
    * value (exclusive). If the value of `gt` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -212,24 +212,24 @@ public interface TimestampRulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the timestamp field value to be greater than the specified
+   * `gt` requires the timestamp field value to be greater than the specified
    * value (exclusive). If the value of `gt` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -238,24 +238,24 @@ public interface TimestampRulesOrBuilder extends
   com.google.protobuf.Timestamp getGt();
   /**
    * <pre>
-   *`gt` requires the timestamp field value to be greater than the specified
+   * `gt` requires the timestamp field value to be greater than the specified
    * value (exclusive). If the value of `gt` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gt = 5 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -264,24 +264,24 @@ public interface TimestampRulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the timestamp field value to be greater than or equal to the
+   * `gte` requires the timestamp field value to be greater than or equal to the
    * specified value (exclusive). If the value of `gte` is larger than a
    * specified `lt` or `lte`, the range is reversed, and the field value
    * must be outside the specified range. If the field value doesn't meet
    * the required conditions, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -290,24 +290,24 @@ public interface TimestampRulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the timestamp field value to be greater than or equal to the
+   * `gte` requires the timestamp field value to be greater than or equal to the
    * specified value (exclusive). If the value of `gte` is larger than a
    * specified `lt` or `lte`, the range is reversed, and the field value
    * must be outside the specified range. If the field value doesn't meet
    * the required conditions, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -316,24 +316,24 @@ public interface TimestampRulesOrBuilder extends
   com.google.protobuf.Timestamp getGte();
   /**
    * <pre>
-   *`gte` requires the timestamp field value to be greater than or equal to the
+   * `gte` requires the timestamp field value to be greater than or equal to the
    * specified value (exclusive). If the value of `gte` is larger than a
    * specified `lt` or `lte`, the range is reversed, and the field value
    * must be outside the specified range. If the field value doesn't meet
    * the required conditions, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-   *  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+   * ```proto
+   * message MyTimestamp {
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+   *   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-   *  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+   *   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+   *   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
    *
-   *  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-   *  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-   *}
-   *```
+   *   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+   *   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+   * }
+   * ```
    * </pre>
    *
    * <code>.google.protobuf.Timestamp gte = 6 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -342,14 +342,14 @@ public interface TimestampRulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+   * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be greater than now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be greater than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -358,14 +358,14 @@ public interface TimestampRulesOrBuilder extends
   boolean hasGtNow();
   /**
    * <pre>
-   *`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+   * `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be greater than now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be greater than now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>bool gt_now = 8 [json_name = "gtNow", (.buf.validate.priv.field) = { ... }</code>
@@ -377,12 +377,12 @@ public interface TimestampRulesOrBuilder extends
    * <pre>
    * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be within 1 hour of now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be within 1 hour of now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -393,12 +393,12 @@ public interface TimestampRulesOrBuilder extends
    * <pre>
    * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be within 1 hour of now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be within 1 hour of now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>
@@ -409,12 +409,12 @@ public interface TimestampRulesOrBuilder extends
    * <pre>
    * `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
    *
-   *```proto
-   *message MyTimestamp {
-   *  // value must be within 1 hour of now
+   * ```proto
+   * message MyTimestamp {
+   *   // value must be within 1 hour of now
    *   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional .google.protobuf.Duration within = 9 [json_name = "within", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/UInt32Rules.java
+++ b/src/main/java/build/buf/validate/UInt32Rules.java
@@ -134,15 +134,15 @@ private static final long serialVersionUID = 0L;
   private int const_ = 0;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt32 {
+   *   // value must equal 42
    *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,15 +154,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt32 {
+   *   // value must equal 42
    *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -176,16 +176,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -197,16 +197,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -223,16 +223,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than or equal to 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -244,16 +244,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than or equal to 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -270,24 +270,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than 5 [uint32.gt]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than 5 [uint32.gt]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -299,24 +299,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than 5 [uint32.gt]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than 5 [uint32.gt]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -333,24 +333,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than or equal to 5 [uint32.gte]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than or equal to 5 [uint32.gte]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -362,24 +362,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than or equal to 5 [uint32.gte]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than or equal to 5 [uint32.gte]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -399,16 +399,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -421,16 +421,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -441,16 +441,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -468,16 +468,16 @@ private static final long serialVersionUID = 0L;
       emptyIntList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -490,16 +490,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -510,16 +510,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1165,15 +1165,15 @@ private static final long serialVersionUID = 0L;
     private int const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt32 {
+     *   // value must equal 42
      *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1185,15 +1185,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt32 {
+     *   // value must equal 42
      *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1205,15 +1205,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt32 {
+     *   // value must equal 42
      *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1229,15 +1229,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt32 {
+     *   // value must equal 42
      *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1252,16 +1252,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1272,16 +1272,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1295,16 +1295,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1320,16 +1320,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1346,16 +1346,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than or equal to 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1366,16 +1366,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than or equal to 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1389,16 +1389,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than or equal to 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1414,16 +1414,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be less than or equal to 10
      *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1440,24 +1440,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than 5 [uint32.gt]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than 5 [uint32.gt]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1468,24 +1468,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than 5 [uint32.gt]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than 5 [uint32.gt]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1499,24 +1499,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than 5 [uint32.gt]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than 5 [uint32.gt]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1532,24 +1532,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than 5 [uint32.gt]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than 5 [uint32.gt]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1566,24 +1566,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than or equal to 5 [uint32.gte]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than or equal to 5 [uint32.gte]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1594,24 +1594,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than or equal to 5 [uint32.gte]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than or equal to 5 [uint32.gte]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1625,24 +1625,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than or equal to 5 [uint32.gte]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than or equal to 5 [uint32.gte]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1658,24 +1658,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be greater than or equal to 5 [uint32.gte]
-     *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be greater than or equal to 5 [uint32.gte]
+     *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-     *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+     *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-     *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+     *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1699,16 +1699,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1721,16 +1721,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1741,16 +1741,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1762,16 +1762,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1790,16 +1790,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1816,16 +1816,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1843,16 +1843,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1874,16 +1874,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1896,16 +1896,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1916,16 +1916,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1937,16 +1937,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1965,16 +1965,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1991,16 +1991,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2018,16 +2018,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt32 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt32 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/UInt32RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/UInt32RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface UInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt32 {
+   *   // value must equal 42
    *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface UInt32RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt32 {
+   *   // value must equal 42
    *   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint32 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface UInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface UInt32RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface UInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than or equal to 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface UInt32RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be less than or equal to 10
    *   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface UInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than 5 [uint32.gt]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than 5 [uint32.gt]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface UInt32RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than 5 [uint32.gt]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than 5 [uint32.gt]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface UInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than or equal to 5 [uint32.gte]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than or equal to 5 [uint32.gte]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface UInt32RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be greater than or equal to 5 [uint32.gte]
-   *  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be greater than or equal to 5 [uint32.gte]
+   *   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-   *  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+   *   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-   *  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+   *   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint32 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface UInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface UInt32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface UInt32RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface UInt32RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface UInt32RulesOrBuilder extends
   java.util.List<java.lang.Integer> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface UInt32RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt32 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt32 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint32 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/UInt64Rules.java
+++ b/src/main/java/build/buf/validate/UInt64Rules.java
@@ -134,15 +134,15 @@ private static final long serialVersionUID = 0L;
   private long const_ = 0L;
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt64 {
+   *   // value must equal 42
    *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -154,15 +154,15 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt64 {
+   *   // value must equal 42
    *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -176,16 +176,16 @@ private static final long serialVersionUID = 0L;
   public static final int LT_FIELD_NUMBER = 2;
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -197,16 +197,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -223,16 +223,16 @@ private static final long serialVersionUID = 0L;
   public static final int LTE_FIELD_NUMBER = 3;
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than or equal to 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -244,16 +244,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than or equal to 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -270,24 +270,24 @@ private static final long serialVersionUID = 0L;
   public static final int GT_FIELD_NUMBER = 4;
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than 5 [uint64.gt]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than 5 [uint64.gt]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -299,24 +299,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than 5 [uint64.gt]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than 5 [uint64.gt]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -333,24 +333,24 @@ private static final long serialVersionUID = 0L;
   public static final int GTE_FIELD_NUMBER = 5;
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than or equal to 5 [uint64.gte]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than or equal to 5 [uint64.gte]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -362,24 +362,24 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than or equal to 5 [uint64.gte]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than or equal to 5 [uint64.gte]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -399,16 +399,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -421,16 +421,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -441,16 +441,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -468,16 +468,16 @@ private static final long serialVersionUID = 0L;
       emptyLongList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -490,16 +490,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -510,16 +510,16 @@ private static final long serialVersionUID = 0L;
   }
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1170,15 +1170,15 @@ private static final long serialVersionUID = 0L;
     private long const_ ;
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt64 {
+     *   // value must equal 42
      *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1190,15 +1190,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt64 {
+     *   // value must equal 42
      *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1210,15 +1210,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt64 {
+     *   // value must equal 42
      *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1234,15 +1234,15 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`const` requires the field value to exactly match the specified value. If
+     * `const` requires the field value to exactly match the specified value. If
      * the field value doesn't match, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must equal 42
+     * ```proto
+     * message MyUInt64 {
+     *   // value must equal 42
      *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -1257,16 +1257,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1277,16 +1277,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1300,16 +1300,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1325,16 +1325,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lt` requires the field value to be less than the specified value (field &lt;
+     * `lt` requires the field value to be less than the specified value (field &lt;
      * value). If the field value is equal to or greater than the specified value,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -1351,16 +1351,16 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than or equal to 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1371,16 +1371,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than or equal to 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1394,16 +1394,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than or equal to 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1419,16 +1419,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`lte` requires the field value to be less than or equal to the specified
+     * `lte` requires the field value to be less than or equal to the specified
      * value (field &lt;= value). If the field value is greater than the specified
      * value, an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be less than or equal to 10
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be less than or equal to 10
      *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-     *}
-     *```
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -1445,24 +1445,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than 5 [uint64.gt]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than 5 [uint64.gt]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1473,24 +1473,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than 5 [uint64.gt]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than 5 [uint64.gt]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1504,24 +1504,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than 5 [uint64.gt]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than 5 [uint64.gt]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1537,24 +1537,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gt` requires the field value to be greater than the specified value
+     * `gt` requires the field value to be greater than the specified value
      * (exclusive). If the value of `gt` is larger than a specified `lt` or
      * `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than 5 [uint64.gt]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than 5 [uint64.gt]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
      *
-     *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+     *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
      *
-     *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -1571,24 +1571,24 @@ private static final long serialVersionUID = 0L;
 
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than or equal to 5 [uint64.gte]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than or equal to 5 [uint64.gte]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1599,24 +1599,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than or equal to 5 [uint64.gte]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than or equal to 5 [uint64.gte]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1630,24 +1630,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than or equal to 5 [uint64.gte]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than or equal to 5 [uint64.gte]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1663,24 +1663,24 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`gte` requires the field value to be greater than or equal to the specified
+     * `gte` requires the field value to be greater than or equal to the specified
      * value (exclusive). If the value of `gte` is larger than a specified `lt`
      * or `lte`, the range is reversed, and the field value must be outside the
      * specified range. If the field value doesn't meet the required conditions,
      * an error message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be greater than or equal to 5 [uint64.gte]
-     *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be greater than or equal to 5 [uint64.gte]
+     *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
      *
-     *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-     *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+     *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+     *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
      *
-     *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-     *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-     *}
-     *```
+     *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+     *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+     * }
+     * ```
      * </pre>
      *
      * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -1704,16 +1704,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1726,16 +1726,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1746,16 +1746,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1767,16 +1767,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1795,16 +1795,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1821,16 +1821,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1848,16 +1848,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`in` requires the field value to be equal to one of the specified values.
+     * `in` requires the field value to be equal to one of the specified values.
      * If the field value isn't one of the specified values, an error message is
      * generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -1879,16 +1879,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1901,16 +1901,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1921,16 +1921,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1942,16 +1942,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1970,16 +1970,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -1996,16 +1996,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -2023,16 +2023,16 @@ private static final long serialVersionUID = 0L;
     }
     /**
      * <pre>
-     *`not_in` requires the field value to not be equal to any of the specified
+     * `not_in` requires the field value to not be equal to any of the specified
      * values. If the field value is one of the specified values, an error
      * message is generated.
      *
-     *```proto
-     *message MyUInt64 {
-     *  // value must not be in list [1, 2, 3]
-     *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-     *}
-     *```
+     * ```proto
+     * message MyUInt64 {
+     *   // value must not be in list [1, 2, 3]
+     *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+     * }
+     * ```
      * </pre>
      *
      * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/java/build/buf/validate/UInt64RulesOrBuilder.java
+++ b/src/main/java/build/buf/validate/UInt64RulesOrBuilder.java
@@ -9,15 +9,15 @@ public interface UInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt64 {
+   *   // value must equal 42
    *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -26,15 +26,15 @@ public interface UInt64RulesOrBuilder extends
   boolean hasConst();
   /**
    * <pre>
-   *`const` requires the field value to exactly match the specified value. If
+   * `const` requires the field value to exactly match the specified value. If
    * the field value doesn't match, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must equal 42
+   * ```proto
+   * message MyUInt64 {
+   *   // value must equal 42
    *   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>optional uint64 const = 1 [json_name = "const", (.buf.validate.priv.field) = { ... }</code>
@@ -44,16 +44,16 @@ public interface UInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -62,16 +62,16 @@ public interface UInt64RulesOrBuilder extends
   boolean hasLt();
   /**
    * <pre>
-   *`lt` requires the field value to be less than the specified value (field &lt;
+   * `lt` requires the field value to be less than the specified value (field &lt;
    * value). If the field value is equal to or greater than the specified value,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lt = 2 [json_name = "lt", (.buf.validate.priv.field) = { ... }</code>
@@ -81,16 +81,16 @@ public interface UInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than or equal to 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -99,16 +99,16 @@ public interface UInt64RulesOrBuilder extends
   boolean hasLte();
   /**
    * <pre>
-   *`lte` requires the field value to be less than or equal to the specified
+   * `lte` requires the field value to be less than or equal to the specified
    * value (field &lt;= value). If the field value is greater than the specified
    * value, an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be less than or equal to 10
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be less than or equal to 10
    *   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-   *}
-   *```
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 lte = 3 [json_name = "lte", (.buf.validate.priv.field) = { ... }</code>
@@ -118,24 +118,24 @@ public interface UInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than 5 [uint64.gt]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than 5 [uint64.gt]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -144,24 +144,24 @@ public interface UInt64RulesOrBuilder extends
   boolean hasGt();
   /**
    * <pre>
-   *`gt` requires the field value to be greater than the specified value
+   * `gt` requires the field value to be greater than the specified value
    * (exclusive). If the value of `gt` is larger than a specified `lt` or
    * `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than 5 [uint64.gt]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than 5 [uint64.gt]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
    *
-   *  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+   *   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
    *
-   *  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gt = 4 [json_name = "gt", (.buf.validate.priv.field) = { ... }</code>
@@ -171,24 +171,24 @@ public interface UInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than or equal to 5 [uint64.gte]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than or equal to 5 [uint64.gte]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -197,24 +197,24 @@ public interface UInt64RulesOrBuilder extends
   boolean hasGte();
   /**
    * <pre>
-   *`gte` requires the field value to be greater than or equal to the specified
+   * `gte` requires the field value to be greater than or equal to the specified
    * value (exclusive). If the value of `gte` is larger than a specified `lt`
    * or `lte`, the range is reversed, and the field value must be outside the
    * specified range. If the field value doesn't meet the required conditions,
    * an error message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be greater than or equal to 5 [uint64.gte]
-   *  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be greater than or equal to 5 [uint64.gte]
+   *   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
    *
-   *  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-   *  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+   *   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+   *   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
    *
-   *  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-   *  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-   *}
-   *```
+   *   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+   *   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+   * }
+   * ```
    * </pre>
    *
    * <code>uint64 gte = 5 [json_name = "gte", (.buf.validate.priv.field) = { ... }</code>
@@ -224,16 +224,16 @@ public interface UInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -242,16 +242,16 @@ public interface UInt64RulesOrBuilder extends
   java.util.List<java.lang.Long> getInList();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -260,16 +260,16 @@ public interface UInt64RulesOrBuilder extends
   int getInCount();
   /**
    * <pre>
-   *`in` requires the field value to be equal to one of the specified values.
+   * `in` requires the field value to be equal to one of the specified values.
    * If the field value isn't one of the specified values, an error message is
    * generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 in = 6 [json_name = "in", (.buf.validate.priv.field) = { ... }</code>
@@ -280,16 +280,16 @@ public interface UInt64RulesOrBuilder extends
 
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -298,16 +298,16 @@ public interface UInt64RulesOrBuilder extends
   java.util.List<java.lang.Long> getNotInList();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>
@@ -316,16 +316,16 @@ public interface UInt64RulesOrBuilder extends
   int getNotInCount();
   /**
    * <pre>
-   *`not_in` requires the field value to not be equal to any of the specified
+   * `not_in` requires the field value to not be equal to any of the specified
    * values. If the field value is one of the specified values, an error
    * message is generated.
    *
-   *```proto
-   *message MyUInt64 {
-   *  // value must not be in list [1, 2, 3]
-   *  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-   *}
-   *```
+   * ```proto
+   * message MyUInt64 {
+   *   // value must not be in list [1, 2, 3]
+   *   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+   * }
+   * ```
    * </pre>
    *
    * <code>repeated uint64 not_in = 7 [json_name = "notIn", (.buf.validate.priv.field) = { ... }</code>

--- a/src/main/resources/buf/validate/validate.proto
+++ b/src/main/resources/buf/validate/validate.proto
@@ -60,7 +60,7 @@ extend google.protobuf.FieldOptions {
 // MessageConstraints represents validation rules that are applied to the entire message.
 // It includes disabling options and a list of Constraint messages representing Common Expression Language (CEL) validation rules.
 message MessageConstraints {
-  // disabled is a boolean flag that, when set to true, nullifies any validation rules for this message.
+  // `disabled` is a boolean flag that, when set to true, nullifies any validation rules for this message.
   // This includes any fields within the message that would otherwise support validation.
   //
   // ```proto
@@ -71,22 +71,22 @@ message MessageConstraints {
   // ```
   optional bool disabled = 1;
 
-  // cel is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
+  // `cel` is a repeated field of type Constraint. Each Constraint specifies a validation rule to be applied to this message.
   // These constraints are written in Common Expression Language (CEL) syntax. For more information on
   // CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
   //
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `foo` must be greater than 42.
-  //  option (buf.validate.message).cel = {
-  //    id: "my_message.value",
-  //    message: "value must be greater than 42",
-  //    expression: "this.foo > 42",
-  //  };
-  //  optional int32 foo = 1;
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   // The field `foo` must be greater than 42.
+  //   option (buf.validate.message).cel = {
+  //     id: "my_message.value",
+  //     message: "value must be greater than 42",
+  //     expression: "this.foo > 42",
+  //   };
+  //   optional int32 foo = 1;
+  // }
+  // ```
   repeated Constraint cel = 3;
 }
 
@@ -95,73 +95,76 @@ message MessageConstraints {
 // that exactly one of the fields within a oneof is set; validation will fail
 // if none of the fields in the oneof are set:
 message OneofConstraints {
-  //`required` is an optional boolean attribute that ensures that
-  //exactly one of the field options in a oneof is set; validation fails if
-  //no fields in the oneof are set.
+  // `required` is an optional boolean attribute that ensures that
+  // exactly one of the field options in a oneof is set; validation fails if
+  // no fields in the oneof are set.
   //
-  //```proto
-  //message MyMessage {
-  //  oneof value {
-  //    // The field `a` or `b` must be set.
-  //    option (buf.validate.oneof).required = true;
-  //    optional string a = 1;
-  //    optional string b = 2;
-  //  }
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   oneof value {
+  //     // The field `a` or `b` must be set.
+  //     option (buf.validate.oneof).required = true;
+  //     optional string a = 1;
+  //     optional string b = 2;
+  //   }
+  // }
+  // ```
   optional bool required = 1;
 }
 
 // FieldRules encapsulates the rules for each type of field. Depending on the
 // field, the correct set should be used to ensure proper validations.
 message FieldConstraints {
-  // `Constraint` is a repeated field used to represent a textual expression
+  // `cel` is a repeated field used to represent a textual expression
   // in the Common Expression Language (CEL) syntax. For more information on
   // CEL, [see our documentation](https://github.com/bufbuild/protovalidate/blob/main/docs/cel.md).
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `value` must be greater than 42.
-  //  optional int32 value = 1 [(buf.validate.field).cel = {
-  //    id: "my_message.value",
-  //    message: "value must be greater than 42",
-  //    expression: "this > 42",
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   // The field `value` must be greater than 42.
+  //   optional int32 value = 1 [(buf.validate.field).cel = {
+  //     id: "my_message.value",
+  //     message: "value must be greater than 42",
+  //     expression: "this > 42",
+  //   }];
+  // }
+  // ```
   repeated Constraint cel = 23;
-  //`skipped` is an optional boolean attribute that specifies that the
-  //validation rules of this field should not be evaluated. If skipped is set to
-  //true, any validation rules set for the field will be ignored.
+  // `skipped` is an optional boolean attribute that specifies that the
+  // validation rules of this field should not be evaluated. If skipped is set to
+  // true, any validation rules set for the field will be ignored.
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `value` must not be set.
-  //  optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
-  //}
-  //```
+  // ```proto
+  // message MyMessage {
+  //   // The field `value` must not be set.
+  //   optional MyOtherMessage value = 1 [(buf.validate.field).skipped = true];
+  // }
+  // ```
   bool skipped = 24;
-  //`required` is an optional boolean attribute that specifies that
-  //this field must be set. If required is set to true, the field value must
-  //not be empty; otherwise, an error message will be generated.
+  // `required` is an optional boolean attribute that specifies that
+  // this field must be set. If required is set to true, the field value must
+  // not be empty; otherwise, an error message will be generated.
   //
-  //```proto
-  //message MyMessage {
-  //  // The field `value` must be set.
-  //  optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
-  //}
-  //```
+  // Note that `required` validates that `repeated` fields are non-empty, that is
+  // setting a `repeated` field as `required` is equivalent to `repeated.min_items = 1`.
+  //
+  // ```proto
+  // message MyMessage {
+  //   // The field `value` must be set.
+  //   optional MyOtherMessage value = 1 [(buf.validate.field).required = true];
+  // }
+  // ```
   bool required = 25;
-  //`ignore_empty` specifies that the validation rules of this field should be
-  //evaluated only if the field isn't empty. If the field is empty, no validation
-  //rules are applied.
+  // `ignore_empty` specifies that the validation rules of this field should be
+  // evaluated only if the field isn't empty. If the field is empty, no validation
+  // rules are applied.
   //
-  //```proto
-  //message MyRepeated {
-  //  // The field `value` validation rules should be evaluated only if the field isn't empty.
-  //  repeated string value = 1 [(buf.validate.field).ignore_empty = true];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // The field `value` validation rules should be evaluated only if the field isn't empty.
+  //   repeated string value = 1 [(buf.validate.field).ignore_empty = true];
+  // }
+  // ```
   bool ignore_empty = 26;
   oneof type {
     // Scalar Field Types
@@ -196,31 +199,31 @@ message FieldConstraints {
 // FloatRules describes the constraints applied to `float` values. These
 // rules may also be applied to the `google.protobuf.FloatValue` Well-Known-Type.
 message FloatRules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyFloat {
-  //  // value must equal 42.0
+  // ```proto
+  // message MyFloat {
+  //   // value must equal 42.0
   //   float value = 1 [(buf.validate.field).float.const = 42.0];
-  //}
-  //```
+  // }
+  // ```
   optional float const = 1 [(priv.field).cel = {
     id: "float.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
 
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be less than 10.0
+    // ```proto
+    // message MyFloat {
+    //   // value must be less than 10.0
     //   float value = 1 [(buf.validate.field).float.lt = 10.0];
-    //}
-    //```
+    // }
+    // ```
     float lt = 2 [(priv.field).cel = {
       id: "float.lt",
       expression:
@@ -228,16 +231,16 @@ message FloatRules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be less than or equal to 10.0
+    // ```proto
+    // message MyFloat {
+    //   // value must be less than or equal to 10.0
     //   float value = 1 [(buf.validate.field).float.lte = 10.0];
-    //}
-    //```
+    // }
+    // ```
     float lte = 3 [(priv.field).cel = {
       id: "float.lte",
       expression:
@@ -247,24 +250,24 @@ message FloatRules {
   }
 
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be greater than 5.0 [float.gt]
-    //  float value = 1 [(buf.validate.field).float.gt = 5.0];
+    // ```proto
+    // message MyFloat {
+    //   // value must be greater than 5.0 [float.gt]
+    //   float value = 1 [(buf.validate.field).float.gt = 5.0];
     //
-    //  // value must be greater than 5 and less than 10.0 [float.gt_lt]
-    //  float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
+    //   // value must be greater than 5 and less than 10.0 [float.gt_lt]
+    //   float other_value = 2 [(buf.validate.field).float = { gt: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
-    //  float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5.0 [float.gt_lt_exclusive]
+    //   float another_value = 3 [(buf.validate.field).float = { gt: 10.0, lt: 5.0 }];
+    // }
+    // ```
     float gt = 4 [
       (priv.field).cel = {
         id: "float.gt",
@@ -298,24 +301,24 @@ message FloatRules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFloat {
-    //  // value must be greater than or equal to 5.0 [float.gte]
-    //  float value = 1 [(buf.validate.field).float.gte = 5.0];
+    // ```proto
+    // message MyFloat {
+    //   // value must be greater than or equal to 5.0 [float.gte]
+    //   float value = 1 [(buf.validate.field).float.gte = 5.0];
     //
-    //  // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
-    //  float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
+    //   // value must be greater than or equal to 5.0 and less than 10.0 [float.gte_lt]
+    //   float other_value = 2 [(buf.validate.field).float = { gte: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
-    //  float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10.0 or less than 5.0 [float.gte_lt_exclusive]
+    //   float another_value = 3 [(buf.validate.field).float = { gte: 10.0, lt: 5.0 }];
+    // }
+    // ```
     float gte = 5 [
       (priv.field).cel = {
         id: "float.gte",
@@ -350,37 +353,37 @@ message FloatRules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MyFloat {
-  //  // value must be in list [1.0, 2.0, 3.0]
-  //  repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyFloat {
+  //   // value must be in list [1.0, 2.0, 3.0]
+  //   repeated float value = 1 (buf.validate.field).float = { in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated float in = 6 [(priv.field).cel = {
     id: "float.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`in` requires the field value to not be equal to any of the specified
+  // `in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyFloat {
-  //  // value must not be in list [1.0, 2.0, 3.0]
-  //  repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyFloat {
+  //   // value must not be in list [1.0, 2.0, 3.0]
+  //   repeated float value = 1 (buf.validate.field).float = { not_in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated float not_in = 7 [(priv.field).cel = {
     id: "float.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
   }];
 
-  //`finite` requires the field value to be finite. If the field value is
+  // `finite` requires the field value to be finite. If the field value is
   // infinite or NaN, an error message is generated.
   bool finite = 8 [(priv.field).cel = {
     id: "float.finite",
@@ -391,15 +394,15 @@ message FloatRules {
 // DoubleRules describes the constraints applied to `double` values. These
 // rules may also be applied to the `google.protobuf.DoubleValue` Well-Known-Type.
 message DoubleRules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyDouble {
-  //  // value must equal 42.0
+  // ```proto
+  // message MyDouble {
+  //   // value must equal 42.0
   //   double value = 1 [(buf.validate.field).double.const = 42.0];
-  //}
-  //```
+  // }
+  // ```
   optional double const = 1 [(priv.field).cel = {
     id: "double.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -409,12 +412,12 @@ message DoubleRules {
     // value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be less than 10.0
+    // ```proto
+    // message MyDouble {
+    //   // value must be less than 10.0
     //   double value = 1 [(buf.validate.field).double.lt = 10.0];
-    //}
-    //```
+    // }
+    // ```
     double lt = 2 [(priv.field).cel = {
       id: "double.lt",
       expression:
@@ -422,16 +425,16 @@ message DoubleRules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified value
+    // `lte` requires the field value to be less than or equal to the specified value
     // (field <= value). If the field value is greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be less than or equal to 10.0
+    // ```proto
+    // message MyDouble {
+    //   // value must be less than or equal to 10.0
     //   double value = 1 [(buf.validate.field).double.lte = 10.0];
-    //}
-    //```
+    // }
+    // ```
     double lte = 3 [(priv.field).cel = {
       id: "double.lte",
       expression:
@@ -446,18 +449,18 @@ message DoubleRules {
     // range. If the field value doesn't meet the required conditions, an error
     // message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be greater than 5.0 [double.gt]
-    //  double value = 1 [(buf.validate.field).double.gt = 5.0];
+    // ```proto
+    // message MyDouble {
+    //   // value must be greater than 5.0 [double.gt]
+    //   double value = 1 [(buf.validate.field).double.gt = 5.0];
     //
-    //  // value must be greater than 5 and less than 10.0 [double.gt_lt]
-    //  double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
+    //   // value must be greater than 5 and less than 10.0 [double.gt_lt]
+    //   double other_value = 2 [(buf.validate.field).double = { gt: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
-    //  double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5.0 [double.gt_lt_exclusive]
+    //   double another_value = 3 [(buf.validate.field).double = { gt: 10.0, lt: 5.0 }];
+    // }
+    // ```
     double gt = 4 [
       (priv.field).cel = {
         id: "double.gt",
@@ -497,18 +500,18 @@ message DoubleRules {
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyDouble {
-    //  // value must be greater than or equal to 5.0 [double.gte]
-    //  double value = 1 [(buf.validate.field).double.gte = 5.0];
+    // ```proto
+    // message MyDouble {
+    //   // value must be greater than or equal to 5.0 [double.gte]
+    //   double value = 1 [(buf.validate.field).double.gte = 5.0];
     //
-    //  // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
-    //  double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
+    //   // value must be greater than or equal to 5.0 and less than 10.0 [double.gte_lt]
+    //   double other_value = 2 [(buf.validate.field).double = { gte: 5.0, lt: 10.0 }];
     //
-    //  // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
-    //  double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10.0 or less than 5.0 [double.gte_lt_exclusive]
+    //   double another_value = 3 [(buf.validate.field).double = { gte: 10.0, lt: 5.0 }];
+    // }
+    // ```
     double gte = 5 [
       (priv.field).cel = {
         id: "double.gte",
@@ -546,33 +549,33 @@ message DoubleRules {
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyDouble {
-  //  // value must be in list [1.0, 2.0, 3.0]
-  //  repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyDouble {
+  //   // value must be in list [1.0, 2.0, 3.0]
+  //   repeated double value = 1 (buf.validate.field).double = { in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated double in = 6 [(priv.field).cel = {
     id: "double.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyDouble {
-  //  // value must not be in list [1.0, 2.0, 3.0]
-  //  repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
-  //}
-  //```
+  // ```proto
+  // message MyDouble {
+  //   // value must not be in list [1.0, 2.0, 3.0]
+  //   repeated double value = 1 (buf.validate.field).double = { not_in: [1.0, 2.0, 3.0] };
+  // }
+  // ```
   repeated double not_in = 7 [(priv.field).cel = {
     id: "double.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
   }];
 
-  //`finite` requires the field value to be finite. If the field value is
+  // `finite` requires the field value to be finite. If the field value is
   // infinite or NaN, an error message is generated.
   bool finite = 8 [(priv.field).cel = {
     id: "double.finite",
@@ -583,15 +586,15 @@ message DoubleRules {
 // Int32Rules describes the constraints applied to `int32` values. These
 // rules may also be applied to the `google.protobuf.Int32Value` Well-Known-Type.
 message Int32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyInt32 {
-  //  // value must equal 42
+  // ```proto
+  // message MyInt32 {
+  //   // value must equal 42
   //   int32 value = 1 [(buf.validate.field).int32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional int32 const = 1 [(priv.field).cel = {
     id: "int32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -601,12 +604,12 @@ message Int32Rules {
     // < value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyInt32 {
+    //   // value must be less than 10
     //   int32 value = 1 [(buf.validate.field).int32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     int32 lt = 2 [(priv.field).cel = {
       id: "int32.lt",
       expression:
@@ -614,16 +617,16 @@ message Int32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyInt32 {
+    //   // value must be less than or equal to 10
     //   int32 value = 1 [(buf.validate.field).int32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     int32 lte = 3 [(priv.field).cel = {
       id: "int32.lte",
       expression:
@@ -632,24 +635,24 @@ message Int32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be greater than 5 [int32.gt]
-    //  int32 value = 1 [(buf.validate.field).int32.gt = 5];
+    // ```proto
+    // message MyInt32 {
+    //   // value must be greater than 5 [int32.gt]
+    //   int32 value = 1 [(buf.validate.field).int32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [int32.gt_lt]
-    //  int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [int32.gt_lt]
+    //   int32 other_value = 2 [(buf.validate.field).int32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
-    //  int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [int32.gt_lt_exclusive]
+    //   int32 another_value = 3 [(buf.validate.field).int32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     int32 gt = 4 [
       (priv.field).cel = {
         id: "int32.gt",
@@ -683,24 +686,24 @@ message Int32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified value
+    // `gte` requires the field value to be greater than or equal to the specified value
     // (exclusive). If the value of `gte` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt32 {
-    //  // value must be greater than or equal to 5 [int32.gte]
-    //  int32 value = 1 [(buf.validate.field).int32.gte = 5];
+    // ```proto
+    // message MyInt32 {
+    //   // value must be greater than or equal to 5 [int32.gte]
+    //   int32 value = 1 [(buf.validate.field).int32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
-    //  int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [int32.gte_lt]
+    //   int32 other_value = 2 [(buf.validate.field).int32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
-    //  int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [int32.gte_lt_exclusive]
+    //   int32 another_value = 3 [(buf.validate.field).int32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     int32 gte = 5 [
       (priv.field).cel = {
         id: "int32.gte",
@@ -735,31 +738,31 @@ message Int32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyInt32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated int32 value = 1 (buf.validate.field).int32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated int32 in = 6 [(priv.field).cel = {
     id: "int32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MyInt32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated int32 value = 1 (buf.validate.field).int32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated int32 not_in = 7 [(priv.field).cel = {
     id: "int32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -769,30 +772,30 @@ message Int32Rules {
 // Int64Rules describes the constraints applied to `int64` values. These
 // rules may also be applied to the `google.protobuf.Int64Value` Well-Known-Type.
 message Int64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyInt64 {
-  //  // value must equal 42
+  // ```proto
+  // message MyInt64 {
+  //   // value must equal 42
   //   int64 value = 1 [(buf.validate.field).int64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional int64 const = 1 [(priv.field).cel = {
     id: "int64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyInt64 {
+    //   // value must be less than 10
     //   int64 value = 1 [(buf.validate.field).int64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     int64 lt = 2 [(priv.field).cel = {
       id: "int64.lt",
       expression:
@@ -800,16 +803,16 @@ message Int64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyInt64 {
+    //   // value must be less than or equal to 10
     //   int64 value = 1 [(buf.validate.field).int64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     int64 lte = 3 [(priv.field).cel = {
       id: "int64.lte",
       expression:
@@ -818,24 +821,24 @@ message Int64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be greater than 5 [int64.gt]
-    //  int64 value = 1 [(buf.validate.field).int64.gt = 5];
+    // ```proto
+    // message MyInt64 {
+    //   // value must be greater than 5 [int64.gt]
+    //   int64 value = 1 [(buf.validate.field).int64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [int64.gt_lt]
-    //  int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [int64.gt_lt]
+    //   int64 other_value = 2 [(buf.validate.field).int64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
-    //  int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [int64.gt_lt_exclusive]
+    //   int64 another_value = 3 [(buf.validate.field).int64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     int64 gt = 4 [
       (priv.field).cel = {
         id: "int64.gt",
@@ -869,24 +872,24 @@ message Int64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyInt64 {
-    //  // value must be greater than or equal to 5 [int64.gte]
-    //  int64 value = 1 [(buf.validate.field).int64.gte = 5];
+    // ```proto
+    // message MyInt64 {
+    //   // value must be greater than or equal to 5 [int64.gte]
+    //   int64 value = 1 [(buf.validate.field).int64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
-    //  int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [int64.gte_lt]
+    //   int64 other_value = 2 [(buf.validate.field).int64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
-    //  int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [int64.gte_lt_exclusive]
+    //   int64 another_value = 3 [(buf.validate.field).int64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     int64 gte = 5 [
       (priv.field).cel = {
         id: "int64.gte",
@@ -921,31 +924,31 @@ message Int64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyInt64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated int64 value = 1 (buf.validate.field).int64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated int64 in = 6 [(priv.field).cel = {
     id: "int64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyInt64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyInt64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated int64 value = 1 (buf.validate.field).int64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated int64 not_in = 7 [(priv.field).cel = {
     id: "int64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -955,30 +958,30 @@ message Int64Rules {
 // UInt32Rules describes the constraints applied to `uint32` values. These
 // rules may also be applied to the `google.protobuf.UInt32Value` Well-Known-Type.
 message UInt32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyUInt32 {
-  //  // value must equal 42
+  // ```proto
+  // message MyUInt32 {
+  //   // value must equal 42
   //   uint32 value = 1 [(buf.validate.field).uint32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional uint32 const = 1 [(priv.field).cel = {
     id: "uint32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be less than 10
     //   uint32 value = 1 [(buf.validate.field).uint32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     uint32 lt = 2 [(priv.field).cel = {
       id: "uint32.lt",
       expression:
@@ -986,16 +989,16 @@ message UInt32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be less than or equal to 10
     //   uint32 value = 1 [(buf.validate.field).uint32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     uint32 lte = 3 [(priv.field).cel = {
       id: "uint32.lte",
       expression:
@@ -1004,24 +1007,24 @@ message UInt32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be greater than 5 [uint32.gt]
-    //  uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be greater than 5 [uint32.gt]
+    //   uint32 value = 1 [(buf.validate.field).uint32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [uint32.gt_lt]
-    //  uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [uint32.gt_lt]
+    //   uint32 other_value = 2 [(buf.validate.field).uint32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
-    //  uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [uint32.gt_lt_exclusive]
+    //   uint32 another_value = 3 [(buf.validate.field).uint32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     uint32 gt = 4 [
       (priv.field).cel = {
         id: "uint32.gt",
@@ -1055,24 +1058,24 @@ message UInt32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt32 {
-    //  // value must be greater than or equal to 5 [uint32.gte]
-    //  uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
+    // ```proto
+    // message MyUInt32 {
+    //   // value must be greater than or equal to 5 [uint32.gte]
+    //   uint32 value = 1 [(buf.validate.field).uint32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
-    //  uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [uint32.gte_lt]
+    //   uint32 other_value = 2 [(buf.validate.field).uint32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
-    //  uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [uint32.gte_lt_exclusive]
+    //   uint32 another_value = 3 [(buf.validate.field).uint32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     uint32 gte = 5 [
       (priv.field).cel = {
         id: "uint32.gte",
@@ -1107,31 +1110,31 @@ message UInt32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyUInt32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated uint32 value = 1 (buf.validate.field).uint32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint32 in = 6 [(priv.field).cel = {
     id: "uint32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyUInt32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated uint32 value = 1 (buf.validate.field).uint32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint32 not_in = 7 [(priv.field).cel = {
     id: "uint32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1141,30 +1144,30 @@ message UInt32Rules {
 // UInt64Rules describes the constraints applied to `uint64` values. These
 // rules may also be applied to the `google.protobuf.UInt64Value` Well-Known-Type.
 message UInt64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyUInt64 {
-  //  // value must equal 42
+  // ```proto
+  // message MyUInt64 {
+  //   // value must equal 42
   //   uint64 value = 1 [(buf.validate.field).uint64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 const = 1 [(priv.field).cel = {
     id: "uint64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be less than 10
     //   uint64 value = 1 [(buf.validate.field).uint64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     uint64 lt = 2 [(priv.field).cel = {
       id: "uint64.lt",
       expression:
@@ -1172,16 +1175,16 @@ message UInt64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be less than or equal to 10
     //   uint64 value = 1 [(buf.validate.field).uint64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     uint64 lte = 3 [(priv.field).cel = {
       id: "uint64.lte",
       expression:
@@ -1190,24 +1193,24 @@ message UInt64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be greater than 5 [uint64.gt]
-    //  uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be greater than 5 [uint64.gt]
+    //   uint64 value = 1 [(buf.validate.field).uint64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [uint64.gt_lt]
-    //  uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [uint64.gt_lt]
+    //   uint64 other_value = 2 [(buf.validate.field).uint64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
-    //  uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [uint64.gt_lt_exclusive]
+    //   uint64 another_value = 3 [(buf.validate.field).uint64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     uint64 gt = 4 [
       (priv.field).cel = {
         id: "uint64.gt",
@@ -1241,24 +1244,24 @@ message UInt64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyUInt64 {
-    //  // value must be greater than or equal to 5 [uint64.gte]
-    //  uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
+    // ```proto
+    // message MyUInt64 {
+    //   // value must be greater than or equal to 5 [uint64.gte]
+    //   uint64 value = 1 [(buf.validate.field).uint64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
-    //  uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [uint64.gte_lt]
+    //   uint64 other_value = 2 [(buf.validate.field).uint64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
-    //  uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [uint64.gte_lt_exclusive]
+    //   uint64 another_value = 3 [(buf.validate.field).uint64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     uint64 gte = 5 [
       (priv.field).cel = {
         id: "uint64.gte",
@@ -1292,31 +1295,31 @@ message UInt64Rules {
       }
     ];
   }
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyUInt64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated uint64 value = 1 (buf.validate.field).uint64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint64 in = 6 [(priv.field).cel = {
     id: "uint64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyUInt64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyUInt64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated uint64 value = 1 (buf.validate.field).uint64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated uint64 not_in = 7 [(priv.field).cel = {
     id: "uint64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1325,30 +1328,30 @@ message UInt64Rules {
 
 // SInt32Rules describes the constraints applied to `sint32` values.
 message SInt32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySInt32 {
-  //  // value must equal 42
+  // ```proto
+  // message MySInt32 {
+  //   // value must equal 42
   //   sint32 value = 1 [(buf.validate.field).sint32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sint32 const = 1 [(priv.field).cel = {
     id: "sint32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field
+    // `lt` requires the field value to be less than the specified value (field
     // < value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySInt32 {
+    //   // value must be less than 10
     //   sint32 value = 1 [(buf.validate.field).sint32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sint32 lt = 2 [(priv.field).cel = {
       id: "sint32.lt",
       expression:
@@ -1356,16 +1359,16 @@ message SInt32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySInt32 {
+    //   // value must be less than or equal to 10
     //   sint32 value = 1 [(buf.validate.field).sint32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sint32 lte = 3 [(priv.field).cel = {
       id: "sint32.lte",
       expression:
@@ -1374,24 +1377,24 @@ message SInt32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
-    //  // value must be greater than 5 [sint32.gt]
-    //  sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
+    // ```proto
+    // message MySInt32 {
+    //   // value must be greater than 5 [sint32.gt]
+    //   sint32 value = 1 [(buf.validate.field).sint32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sint32.gt_lt]
-    //  sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sint32.gt_lt]
+    //   sint32 other_value = 2 [(buf.validate.field).sint32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
-    //  sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sint32.gt_lt_exclusive]
+    //   sint32 another_value = 3 [(buf.validate.field).sint32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sint32 gt = 4 [
       (priv.field).cel = {
         id: "sint32.gt",
@@ -1425,14 +1428,14 @@ message SInt32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt32 {
+    // ```proto
+    // message MySInt32 {
     //  // value must be greater than or equal to 5 [sint32.gte]
     //  sint32 value = 1 [(buf.validate.field).sint32.gte = 5];
     //
@@ -1441,8 +1444,8 @@ message SInt32Rules {
     //
     //  // value must be greater than or equal to 10 or less than 5 [sint32.gte_lt_exclusive]
     //  sint32 another_value = 3 [(buf.validate.field).sint32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    // }
+    // ```
     sint32 gte = 5 [
       (priv.field).cel = {
         id: "sint32.gte",
@@ -1477,31 +1480,31 @@ message SInt32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MySInt32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sint32 value = 1 (buf.validate.field).sint32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint32 in = 6 [(priv.field).cel = {
     id: "sint32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySInt32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sint32 value = 1 (buf.validate.field).sint32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint32 not_in = 7 [(priv.field).cel = {
     id: "sint32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1510,30 +1513,30 @@ message SInt32Rules {
 
 // SInt64Rules describes the constraints applied to `sint64` values.
 message SInt64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySInt64 {
-  //  // value must equal 42
+  // ```proto
+  // message MySInt64 {
+  //   // value must equal 42
   //   sint64 value = 1 [(buf.validate.field).sint64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sint64 const = 1 [(priv.field).cel = {
     id: "sint64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field
+    // `lt` requires the field value to be less than the specified value (field
     // < value). If the field value is equal to or greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySInt64 {
+    //   // value must be less than 10
     //   sint64 value = 1 [(buf.validate.field).sint64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sint64 lt = 2 [(priv.field).cel = {
       id: "sint64.lt",
       expression:
@@ -1541,16 +1544,16 @@ message SInt64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySInt64 {
+    //   // value must be less than or equal to 10
     //   sint64 value = 1 [(buf.validate.field).sint64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sint64 lte = 3 [(priv.field).cel = {
       id: "sint64.lte",
       expression:
@@ -1559,24 +1562,24 @@ message SInt64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be greater than 5 [sint64.gt]
-    //  sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
+    // ```proto
+    // message MySInt64 {
+    //   // value must be greater than 5 [sint64.gt]
+    //   sint64 value = 1 [(buf.validate.field).sint64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sint64.gt_lt]
-    //  sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sint64.gt_lt]
+    //   sint64 other_value = 2 [(buf.validate.field).sint64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
-    //  sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sint64.gt_lt_exclusive]
+    //   sint64 another_value = 3 [(buf.validate.field).sint64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sint64 gt = 4 [
       (priv.field).cel = {
         id: "sint64.gt",
@@ -1610,24 +1613,24 @@ message SInt64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySInt64 {
-    //  // value must be greater than or equal to 5 [sint64.gte]
-    //  sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
+    // ```proto
+    // message MySInt64 {
+    //   // value must be greater than or equal to 5 [sint64.gte]
+    //   sint64 value = 1 [(buf.validate.field).sint64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
-    //  sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [sint64.gte_lt]
+    //   sint64 other_value = 2 [(buf.validate.field).sint64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
-    //  sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [sint64.gte_lt_exclusive]
+    //   sint64 another_value = 3 [(buf.validate.field).sint64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     sint64 gte = 5 [
       (priv.field).cel = {
         id: "sint64.gte",
@@ -1662,31 +1665,31 @@ message SInt64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MySInt64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sint64 value = 1 (buf.validate.field).sint64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint64 in = 6 [(priv.field).cel = {
     id: "sint64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySInt64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySInt64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sint64 value = 1 (buf.validate.field).sint64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sint64 not_in = 7 [(priv.field).cel = {
     id: "sint64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1695,30 +1698,30 @@ message SInt64Rules {
 
 // Fixed32Rules describes the constraints applied to `fixed32` values.
 message Fixed32Rules {
-  //`const` requires the field value to exactly match the specified value.
+  // `const` requires the field value to exactly match the specified value.
   // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyFixed32 {
-  //  // value must equal 42
+  // ```proto
+  // message MyFixed32 {
+  //   // value must equal 42
   //   fixed32 value = 1 [(buf.validate.field).fixed32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional fixed32 const = 1 [(priv.field).cel = {
     id: "fixed32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be less than 10
     //   fixed32 value = 1 [(buf.validate.field).fixed32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed32 lt = 2 [(priv.field).cel = {
       id: "fixed32.lt",
       expression:
@@ -1726,16 +1729,16 @@ message Fixed32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be less than or equal to 10
     //   fixed32 value = 1 [(buf.validate.field).fixed32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed32 lte = 3 [(priv.field).cel = {
       id: "fixed32.lte",
       expression:
@@ -1744,24 +1747,24 @@ message Fixed32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be greater than 5 [fixed32.gt]
-    //  fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be greater than 5 [fixed32.gt]
+    //   fixed32 value = 1 [(buf.validate.field).fixed32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [fixed32.gt_lt]
-    //  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [fixed32.gt_lt]
+    //   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
-    //  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [fixed32.gt_lt_exclusive]
+    //   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     fixed32 gt = 4 [
       (priv.field).cel = {
         id: "fixed32.gt",
@@ -1795,24 +1798,24 @@ message Fixed32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed32 {
-    //  // value must be greater than or equal to 5 [fixed32.gte]
-    //  fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
+    // ```proto
+    // message MyFixed32 {
+    //   // value must be greater than or equal to 5 [fixed32.gte]
+    //   fixed32 value = 1 [(buf.validate.field).fixed32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
-    //  fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [fixed32.gte_lt]
+    //   fixed32 other_value = 2 [(buf.validate.field).fixed32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
-    //  fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [fixed32.gte_lt_exclusive]
+    //   fixed32 another_value = 3 [(buf.validate.field).fixed32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     fixed32 gte = 5 [
       (priv.field).cel = {
         id: "fixed32.gte",
@@ -1847,31 +1850,31 @@ message Fixed32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message
   // is generated.
   //
-  //```proto
-  //message MyFixed32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed32 in = 6 [(priv.field).cel = {
     id: "fixed32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyFixed32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated fixed32 value = 1 (buf.validate.field).fixed32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed32 not_in = 7 [(priv.field).cel = {
     id: "fixed32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -1880,30 +1883,30 @@ message Fixed32Rules {
 
 // Fixed64Rules describes the constraints applied to `fixed64` values.
 message Fixed64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyFixed64 {
-  //  // value must equal 42
+  // ```proto
+  // message MyFixed64 {
+  //   // value must equal 42
   //   fixed64 value = 1 [(buf.validate.field).fixed64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional fixed64 const = 1 [(priv.field).cel = {
     id: "fixed64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be less than 10
     //   fixed64 value = 1 [(buf.validate.field).fixed64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed64 lt = 2 [(priv.field).cel = {
       id: "fixed64.lt",
       expression:
@@ -1911,16 +1914,16 @@ message Fixed64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be less than or equal to 10
     //   fixed64 value = 1 [(buf.validate.field).fixed64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     fixed64 lte = 3 [(priv.field).cel = {
       id: "fixed64.lte",
       expression:
@@ -1929,24 +1932,24 @@ message Fixed64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be greater than 5 [fixed64.gt]
-    //  fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be greater than 5 [fixed64.gt]
+    //   fixed64 value = 1 [(buf.validate.field).fixed64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [fixed64.gt_lt]
-    //  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [fixed64.gt_lt]
+    //   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
-    //  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [fixed64.gt_lt_exclusive]
+    //   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     fixed64 gt = 4 [
       (priv.field).cel = {
         id: "fixed64.gt",
@@ -1980,24 +1983,24 @@ message Fixed64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyFixed64 {
-    //  // value must be greater than or equal to 5 [fixed64.gte]
-    //  fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
+    // ```proto
+    // message MyFixed64 {
+    //   // value must be greater than or equal to 5 [fixed64.gte]
+    //   fixed64 value = 1 [(buf.validate.field).fixed64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
-    //  fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [fixed64.gte_lt]
+    //   fixed64 other_value = 2 [(buf.validate.field).fixed64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
-    //  fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [fixed64.gte_lt_exclusive]
+    //   fixed64 another_value = 3 [(buf.validate.field).fixed64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     fixed64 gte = 5 [
       (priv.field).cel = {
         id: "fixed64.gte",
@@ -2032,31 +2035,31 @@ message Fixed64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MyFixed64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed64 in = 6 [(priv.field).cel = {
     id: "fixed64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MyFixed64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MyFixed64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated fixed64 value = 1 (buf.validate.field).fixed64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated fixed64 not_in = 7 [(priv.field).cel = {
     id: "fixed64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -2065,30 +2068,30 @@ message Fixed64Rules {
 
 // SFixed32Rules describes the constraints applied to `fixed32` values.
 message SFixed32Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySFixed32 {
-  //  // value must equal 42
+  // ```proto
+  // message MySFixed32 {
+  //   // value must equal 42
   //   sfixed32 value = 1 [(buf.validate.field).sfixed32.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sfixed32 const = 1 [(priv.field).cel = {
     id: "sfixed32.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be less than 10
     //   sfixed32 value = 1 [(buf.validate.field).sfixed32.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed32 lt = 2 [(priv.field).cel = {
       id: "sfixed32.lt",
       expression:
@@ -2096,16 +2099,16 @@ message SFixed32Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be less than or equal to 10
     //   sfixed32 value = 1 [(buf.validate.field).sfixed32.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed32 lte = 3 [(priv.field).cel = {
       id: "sfixed32.lte",
       expression:
@@ -2114,24 +2117,24 @@ message SFixed32Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be greater than 5 [sfixed32.gt]
-    //  sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be greater than 5 [sfixed32.gt]
+    //   sfixed32 value = 1 [(buf.validate.field).sfixed32.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
-    //  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sfixed32.gt_lt]
+    //   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
-    //  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sfixed32.gt_lt_exclusive]
+    //   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sfixed32 gt = 4 [
       (priv.field).cel = {
         id: "sfixed32.gt",
@@ -2165,24 +2168,24 @@ message SFixed32Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed32 {
-    //  // value must be greater than or equal to 5 [sfixed32.gte]
-    //  sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
+    // ```proto
+    // message MySFixed32 {
+    //   // value must be greater than or equal to 5 [sfixed32.gte]
+    //   sfixed32 value = 1 [(buf.validate.field).sfixed32.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
-    //  sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [sfixed32.gte_lt]
+    //   sfixed32 other_value = 2 [(buf.validate.field).sfixed32 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
-    //  sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [sfixed32.gte_lt_exclusive]
+    //   sfixed32 another_value = 3 [(buf.validate.field).sfixed32 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     sfixed32 gte = 5 [
       (priv.field).cel = {
         id: "sfixed32.gte",
@@ -2217,31 +2220,31 @@ message SFixed32Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MySFixed32 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed32 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed32 in = 6 [(priv.field).cel = {
     id: "sfixed32.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySFixed32 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed32 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sfixed32 value = 1 (buf.validate.field).sfixed32 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed32 not_in = 7 [(priv.field).cel = {
     id: "sfixed32.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -2250,30 +2253,30 @@ message SFixed32Rules {
 
 // SFixed64Rules describes the constraints applied to `fixed64` values.
 message SFixed64Rules {
-  //`const` requires the field value to exactly match the specified value. If
+  // `const` requires the field value to exactly match the specified value. If
   // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MySFixed64 {
-  //  // value must equal 42
+  // ```proto
+  // message MySFixed64 {
+  //   // value must equal 42
   //   sfixed64 value = 1 [(buf.validate.field).sfixed64.const = 42];
-  //}
-  //```
+  // }
+  // ```
   optional sfixed64 const = 1 [(priv.field).cel = {
     id: "sfixed64.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` requires the field value to be less than the specified value (field <
+    // `lt` requires the field value to be less than the specified value (field <
     // value). If the field value is equal to or greater than the specified value,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be less than 10
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be less than 10
     //   sfixed64 value = 1 [(buf.validate.field).sfixed64.lt = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed64 lt = 2 [(priv.field).cel = {
       id: "sfixed64.lt",
       expression:
@@ -2281,16 +2284,16 @@ message SFixed64Rules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` requires the field value to be less than or equal to the specified
+    // `lte` requires the field value to be less than or equal to the specified
     // value (field <= value). If the field value is greater than the specified
     // value, an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be less than or equal to 10
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be less than or equal to 10
     //   sfixed64 value = 1 [(buf.validate.field).sfixed64.lte = 10];
-    //}
-    //```
+    // }
+    // ```
     sfixed64 lte = 3 [(priv.field).cel = {
       id: "sfixed64.lte",
       expression:
@@ -2299,24 +2302,24 @@ message SFixed64Rules {
     }];
   }
   oneof greater_than {
-    //`gt` requires the field value to be greater than the specified value
+    // `gt` requires the field value to be greater than the specified value
     // (exclusive). If the value of `gt` is larger than a specified `lt` or
     // `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be greater than 5 [sfixed64.gt]
-    //  sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be greater than 5 [sfixed64.gt]
+    //   sfixed64 value = 1 [(buf.validate.field).sfixed64.gt = 5];
     //
-    //  // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
-    //  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
+    //   // value must be greater than 5 and less than 10 [sfixed64.gt_lt]
+    //   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gt: 5, lt: 10 }];
     //
-    //  // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
-    //  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than 10 or less than 5 [sfixed64.gt_lt_exclusive]
+    //   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gt: 10, lt: 5 }];
+    // }
+    // ```
     sfixed64 gt = 4 [
       (priv.field).cel = {
         id: "sfixed64.gt",
@@ -2350,24 +2353,24 @@ message SFixed64Rules {
       }
     ];
 
-    //`gte` requires the field value to be greater than or equal to the specified
+    // `gte` requires the field value to be greater than or equal to the specified
     // value (exclusive). If the value of `gte` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MySFixed64 {
-    //  // value must be greater than or equal to 5 [sfixed64.gte]
-    //  sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
+    // ```proto
+    // message MySFixed64 {
+    //   // value must be greater than or equal to 5 [sfixed64.gte]
+    //   sfixed64 value = 1 [(buf.validate.field).sfixed64.gte = 5];
     //
-    //  // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
-    //  sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
+    //   // value must be greater than or equal to 5 and less than 10 [sfixed64.gte_lt]
+    //   sfixed64 other_value = 2 [(buf.validate.field).sfixed64 = { gte: 5, lt: 10 }];
     //
-    //  // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
-    //  sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
-    //}
-    //```
+    //   // value must be greater than or equal to 10 or less than 5 [sfixed64.gte_lt_exclusive]
+    //   sfixed64 another_value = 3 [(buf.validate.field).sfixed64 = { gte: 10, lt: 5 }];
+    // }
+    // ```
     sfixed64 gte = 5 [
       (priv.field).cel = {
         id: "sfixed64.gte",
@@ -2402,31 +2405,31 @@ message SFixed64Rules {
     ];
   }
 
-  //`in` requires the field value to be equal to one of the specified values.
+  // `in` requires the field value to be equal to one of the specified values.
   // If the field value isn't one of the specified values, an error message is
   // generated.
   //
-  //```proto
-  //message MySFixed64 {
-  //  // value must be in list [1, 2, 3]
-  //  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed64 {
+  //   // value must be in list [1, 2, 3]
+  //   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed64 in = 6 [(priv.field).cel = {
     id: "sfixed64.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to not be equal to any of the specified
+  // `not_in` requires the field value to not be equal to any of the specified
   // values. If the field value is one of the specified values, an error
   // message is generated.
   //
-  //```proto
-  //message MySFixed64 {
-  //  // value must not be in list [1, 2, 3]
-  //  repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
-  //}
-  //```
+  // ```proto
+  // message MySFixed64 {
+  //   // value must not be in list [1, 2, 3]
+  //   repeated sfixed64 value = 1 (buf.validate.field).sfixed64 = { not_in: [1, 2, 3] };
+  // }
+  // ```
   repeated sfixed64 not_in = 7 [(priv.field).cel = {
     id: "sfixed64.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -2436,15 +2439,15 @@ message SFixed64Rules {
 // BoolRules describes the constraints applied to `bool` values. These rules
 // may also be applied to the `google.protobuf.BoolValue` Well-Known-Type.
 message BoolRules {
-  //`const` requires the field value to exactly match the specified boolean value.
-  //If the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified boolean value.
+  // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyBool {
-  //  // value must equal true
+  // ```proto
+  // message MyBool {
+  //   // value must equal true
   //   bool value = 1 [(buf.validate.field).bool.const = true];
-  //}
-  //```
+  // }
+  // ```
   optional bool const = 1 [(priv.field).cel = {
     id: "bool.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -2454,215 +2457,215 @@ message BoolRules {
 // StringRules describes the constraints applied to `string` values These
 // rules may also be applied to the `google.protobuf.StringValue` Well-Known-Type.
 message StringRules {
-  //`const` requires the field value to exactly match the specified value. If
-  //the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified value. If
+  // the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyString {
-  //  // value must equal `hello`
+  // ```proto
+  // message MyString {
+  //   // value must equal `hello`
   //   string value = 1 [(buf.validate.field).string.const = "hello"];
-  //}
-  //```
+  // }
+  // ```
   optional string const = 1 [(priv.field).cel = {
     id: "string.const",
     expression: "this != rules.const ? 'value must equal `%s`'.format([rules.const]) : ''"
   }];
 
-  //`len` dictates that the field value must have the specified
-  //number of characters (Unicode code points), which may differ from the number
-  //of bytes in the string. If the field value does not meet the specified
-  //length, an error message will be generated.
+  // `len` dictates that the field value must have the specified
+  // number of characters (Unicode code points), which may differ from the number
+  // of bytes in the string. If the field value does not meet the specified
+  // length, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be 5 characters
+  // ```proto
+  // message MyString {
+  //   // value length must be 5 characters
   //   string value = 1 [(buf.validate.field).string.len = 5];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 len = 19 [(priv.field).cel = {
     id: "string.len",
     expression: "uint(this.size()) != rules.len ? 'value length must be %s characters'.format([rules.len]) : ''"
   }];
 
-  //`min_len` specifies that the field value must have at least the specified
-  //number of characters (Unicode code points), which may differ from the number
-  //of bytes in the string. If the field value contains fewer characters, an error
-  //message will be generated.
+  // `min_len` specifies that the field value must have at least the specified
+  // number of characters (Unicode code points), which may differ from the number
+  // of bytes in the string. If the field value contains fewer characters, an error
+  // message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at least 3 characters
+  // ```proto
+  // message MyString {
+  //   // value length must be at least 3 characters
   //   string value = 1 [(buf.validate.field).string.min_len = 3];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 min_len = 2 [(priv.field).cel = {
     id: "string.min_len",
     expression: "uint(this.size()) < rules.min_len ? 'value length must be at least %s characters'.format([rules.min_len]) : ''"
   }];
 
-  //`max_len` specifies that the field value must have no more than the specified
-  //number of characters (Unicode code points), which may differ from the
-  //number of bytes in the string. If the field value contains more characters,
-  //an error message will be generated.
+  // `max_len` specifies that the field value must have no more than the specified
+  // number of characters (Unicode code points), which may differ from the
+  // number of bytes in the string. If the field value contains more characters,
+  // an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at most 10 characters
+  // ```proto
+  // message MyString {
+  //   // value length must be at most 10 characters
   //   string value = 1 [(buf.validate.field).string.max_len = 10];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 max_len = 3 [(priv.field).cel = {
     id: "string.max_len",
     expression: "uint(this.size()) > rules.max_len ? 'value length must be at most %s characters'.format([rules.max_len]) : ''"
   }];
 
-  //`len_bytes` dictates that the field value must have the specified number of
-  //bytes. If the field value does not match the specified length in bytes,
-  //an error message will be generated.
+  // `len_bytes` dictates that the field value must have the specified number of
+  // bytes. If the field value does not match the specified length in bytes,
+  // an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be 6 bytes
+  // ```proto
+  // message MyString {
+  //   // value length must be 6 bytes
   //   string value = 1 [(buf.validate.field).string.len_bytes = 6];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 len_bytes = 20 [(priv.field).cel = {
     id: "string.len_bytes",
     expression: "uint(bytes(this).size()) != rules.len_bytes ? 'value length must be %s bytes'.format([rules.len_bytes]) : ''"
   }];
 
-  //`min_bytes` specifies that the field value must have at least the specified
-  //number of bytes. If the field value contains fewer bytes, an error message
-  //will be generated.
+  // `min_bytes` specifies that the field value must have at least the specified
+  // number of bytes. If the field value contains fewer bytes, an error message
+  // will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at least 4 bytes
+  // ```proto
+  // message MyString {
+  //   // value length must be at least 4 bytes
   //   string value = 1 [(buf.validate.field).string.min_bytes = 4];
-  //}
+  // }
   //
-  //```
+  // ```
   optional uint64 min_bytes = 4 [(priv.field).cel = {
     id: "string.min_bytes",
     expression: "uint(bytes(this).size()) < rules.min_bytes ? 'value length must be at least %s bytes'.format([rules.min_bytes]) : ''"
   }];
 
-  //`max_bytes` specifies that the field value must have no more than the
+  // `max_bytes` specifies that the field value must have no more than the
   //specified number of bytes. If the field value contains more bytes, an
-  //error message will be generated.
+  // error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value length must be at most 8 bytes
+  // ```proto
+  // message MyString {
+  //   // value length must be at most 8 bytes
   //   string value = 1 [(buf.validate.field).string.max_bytes = 8];
-  //}
-  //```
+  // }
+  // ```
   optional uint64 max_bytes = 5 [(priv.field).cel = {
     id: "string.max_bytes",
     expression: "uint(bytes(this).size()) > rules.max_bytes ? 'value length must be at most %s bytes'.format([rules.max_bytes]) : ''",
   }];
 
-  //`pattern` specifies that the field value must match the specified
-  //regular expression (RE2 syntax), with the expression provided without any
-  //delimiters. If the field value doesn't match the regular expression, an
-  //error message will be generated.
+  // `pattern` specifies that the field value must match the specified
+  // regular expression (RE2 syntax), with the expression provided without any
+  // delimiters. If the field value doesn't match the regular expression, an
+  // error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not match regex pattern `^[a-zA-Z]//$`
+  // ```proto
+  // message MyString {
+  //   // value does not match regex pattern `^[a-zA-Z]//$`
   //   string value = 1 [(buf.validate.field).string.pattern = "^[a-zA-Z]//$"];
-  //}
-  //```
+  // }
+  // ```
   optional string pattern = 6 [(priv.field).cel = {
     id: "string.pattern",
     expression: "!this.matches(rules.pattern) ? 'value does not match regex pattern `%s`'.format([rules.pattern]) : ''"
   }];
 
-  //`prefix` specifies that the field value must have the
+  // `prefix` specifies that the field value must have the
   //specified substring at the beginning of the string. If the field value
-  //doesn't start with the specified prefix, an error message will be
-  //generated.
+  // doesn't start with the specified prefix, an error message will be
+  // generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not have prefix `pre`
+  // ```proto
+  // message MyString {
+  //   // value does not have prefix `pre`
   //   string value = 1 [(buf.validate.field).string.prefix = "pre"];
-  //}
-  //```
+  // }
+  // ```
   optional string prefix = 7 [(priv.field).cel = {
     id: "string.prefix",
     expression: "!this.startsWith(rules.prefix) ? 'value does not have prefix `%s`'.format([rules.prefix]) : ''"
   }];
 
-  //`suffix` specifies that the field value must have the
+  // `suffix` specifies that the field value must have the
   //specified substring at the end of the string. If the field value doesn't
-  //end with the specified suffix, an error message will be generated.
+  // end with the specified suffix, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not have suffix `post`
+  // ```proto
+  // message MyString {
+  //   // value does not have suffix `post`
   //   string value = 1 [(buf.validate.field).string.suffix = "post"];
-  //}
-  //```
+  // }
+  // ```
   optional string suffix = 8 [(priv.field).cel = {
     id: "string.suffix",
     expression: "!this.endsWith(rules.suffix) ? 'value does not have suffix `%s`'.format([rules.suffix]) : ''"
   }];
 
-  //`contains` specifies that the field value must have the
+  // `contains` specifies that the field value must have the
   //specified substring anywhere in the string. If the field value doesn't
-  //contain the specified substring, an error message will be generated.
+  // contain the specified substring, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value does not contain substring `inside`.
+  // ```proto
+  // message MyString {
+  //   // value does not contain substring `inside`.
   //   string value = 1 [(buf.validate.field).string.contains = "inside"];
-  //}
-  //```
+  // }
+  // ```
   optional string contains = 9 [(priv.field).cel = {
     id: "string.contains",
     expression: "!this.contains(rules.contains) ? 'value does not contain substring `%s`'.format([rules.contains]) : ''"
   }];
 
-  //`not_contains` specifies that the field value must not have the
+  // `not_contains` specifies that the field value must not have the
   //specified substring anywhere in the string. If the field value contains
-  //the specified substring, an error message will be generated.
+  // the specified substring, an error message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value contains substring `inside`.
+  // ```proto
+  // message MyString {
+  //   // value contains substring `inside`.
   //   string value = 1 [(buf.validate.field).string.not_contains = "inside"];
-  //}
-  //```
+  // }
+  // ```
   optional string not_contains = 23 [(priv.field).cel = {
     id: "string.not_contains",
     expression: "this.contains(rules.not_contains) ? 'value contains substring `%s`'.format([rules.not_contains]) : ''"
   }];
 
-  //`in` specifies that the field value must be equal to one of the specified
-  //values. If the field value isn't one of the specified values, an error
-  //message will be generated.
+  // `in` specifies that the field value must be equal to one of the specified
+  // values. If the field value isn't one of the specified values, an error
+  // message will be generated.
   //
-  //```proto
-  //message MyString {
-  //  // value must be in list ["apple", "banana"]
-  //  repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
-  //}
-  //```
+  // ```proto
+  // message MyString {
+  //   // value must be in list ["apple", "banana"]
+  //   repeated string value = 1 [(buf.validate.field).string.in = "apple", (buf.validate.field).string.in = "banana"];
+  // }
+  // ```
   repeated string in = 10 [(priv.field).cel = {
     id: "string.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''"
   }];
 
-  //`not_in` specifies that the field value cannot be equal to any
-  //of the specified values. If the field value is one of the specified values,
-  //an error message will be generated.
-  //```proto
-  //message MyString {
-  //  // value must not be in list ["orange", "grape"]
-  //  repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
-  //}
-  //```
+  // `not_in` specifies that the field value cannot be equal to any
+  // of the specified values. If the field value is one of the specified values,
+  // an error message will be generated.
+  // ```proto
+  // message MyString {
+  //   // value must not be in list ["orange", "grape"]
+  //   repeated string value = 1 [(buf.validate.field).string.not_in = "orange", (buf.validate.field).string.not_in = "grape"];
+  // }
+  // ```
   repeated string not_in = 11 [(priv.field).cel = {
     id: "string.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''"
@@ -2671,173 +2674,173 @@ message StringRules {
   // `WellKnown` rules provide advanced constraints against common string
   // patterns
   oneof well_known {
-    //`email` specifies that the field value must be a valid email address
-    //(addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
-    //If the field value isn't a valid email address, an error message will be generated.
+    // `email` specifies that the field value must be a valid email address
+    // (addr-spec only) as defined by [RFC 5322](https://tools.ietf.org/html/rfc5322#section-3.4.1).
+    // If the field value isn't a valid email address, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid email address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid email address
     //   string value = 1 [(buf.validate.field).string.email = true];
-    //}
-    //```
+    // }
+    // ```
     bool email = 12 [(priv.field).cel = {
       id: "string.email",
       message: "value must be a valid email address",
       expression: "this.isEmail()"
     }];
 
-    //`hostname` specifies that the field value must be a valid
-    //hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
-    //internationalized domain names (IDNs). If the field value isn't a
-    //valid hostname, an error message will be generated.
+    // `hostname` specifies that the field value must be a valid
+    // hostname as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5). This constraint doesn't support
+    // internationalized domain names (IDNs). If the field value isn't a
+    // valid hostname, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid hostname
+    // ```proto
+    // message MyString {
+    //   // value must be a valid hostname
     //   string value = 1 [(buf.validate.field).string.hostname = true];
-    //}
-    //```
+    // }
+    // ```
     bool hostname = 13 [(priv.field).cel = {
       id: "string.hostname",
       message: "value must be a valid hostname",
       expression: "this.isHostname()",
     }];
 
-    //`ip` specifies that the field value must be a valid IP
-    //(v4 or v6) address, without surrounding square brackets for IPv6 addresses.
-    //If the field value isn't a valid IP address, an error message will be
-    //generated.
+    // `ip` specifies that the field value must be a valid IP
+    // (v4 or v6) address, without surrounding square brackets for IPv6 addresses.
+    // If the field value isn't a valid IP address, an error message will be
+    // generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid IP address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid IP address
     //   string value = 1 [(buf.validate.field).string.ip = true];
-    //}
-    //```
+    // }
+    // ```
     bool ip = 14 [(priv.field).cel = {
       id: "string.ip",
       message: "value must be a valid IP address",
       expression: "this.isIp()",
     }];
 
-    //`ipv4` specifies that the field value must be a valid IPv4
-    //address. If the field value isn't a valid IPv4 address, an error message
-    //will be generated.
+    // `ipv4` specifies that the field value must be a valid IPv4
+    // address. If the field value isn't a valid IPv4 address, an error message
+    // will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid IPv4 address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid IPv4 address
     //   string value = 1 [(buf.validate.field).string.ipv4 = true];
-    //}
-    //```
+    // }
+    // ```
     bool ipv4 = 15 [(priv.field).cel = {
       id: "string.ipv4",
       message: "value must be a valid IPv4 address",
       expression: "this.isIp(4)"
     }];
 
-    //`ipv6` specifies that the field value must be a valid
-    //IPv6 address, without surrounding square brackets. If the field value is
-    //not a valid IPv6 address, an error message will be generated.
+    // `ipv6` specifies that the field value must be a valid
+    // IPv6 address, without surrounding square brackets. If the field value is
+    // not a valid IPv6 address, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid IPv6 address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid IPv6 address
     //   string value = 1 [(buf.validate.field).string.ipv6 = true];
-    //}
-    //```
+    // }
+    // ```
     bool ipv6 = 16 [(priv.field).cel = {
       id: "string.ipv6",
       message: "value must be a valid IPv6 address",
       expression: "this.isIp(6)",
     }];
 
-    //`uri` specifies that the field value must be a valid,
-    //absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
-    //absolute URI, an error message will be generated.
+    // `uri` specifies that the field value must be a valid,
+    // absolute URI as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3). If the field value isn't a valid,
+    // absolute URI, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid URI
+    // ```proto
+    // message MyString {
+    //   // value must be a valid URI
     //   string value = 1 [(buf.validate.field).string.uri = true];
-    //}
-    //```
+    // }
+    // ```
     bool uri = 17 [(priv.field).cel = {
       id: "string.uri",
       message: "value must be a valid URI",
       expression: "this.isUri()",
     }];
 
-    //`uri_ref` specifies that the field value must be a valid URI
-    //as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
-    //field value isn't a valid URI, an error message will be generated.
+    // `uri_ref` specifies that the field value must be a valid URI
+    // as defined by [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3) and may be either relative or absolute. If the
+    // field value isn't a valid URI, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid URI
+    // ```proto
+    // message MyString {
+    //   // value must be a valid URI
     //   string value = 1 [(buf.validate.field).string.uri_ref = true];
-    //}
-    //```
+    // }
+    // ```
     bool uri_ref = 18 [(priv.field).cel = {
       id: "string.uri_ref",
       message: "value must be a valid URI",
       expression: "this.isUriRef()",
     }];
 
-    //`address` specifies that the field value must be either a valid hostname
-    //as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
-    //(which doesn't support internationalized domain names or IDNs) or a valid
-    //IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
-    //message will be generated.
+    // `address` specifies that the field value must be either a valid hostname
+    // as defined by [RFC 1034](https://tools.ietf.org/html/rfc1034#section-3.5)
+    // (which doesn't support internationalized domain names or IDNs) or a valid
+    // IP (v4 or v6). If the field value isn't a valid hostname or IP, an error
+    // message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid hostname, or ip address
+    // ```proto
+    // message MyString {
+    //   // value must be a valid hostname, or ip address
     //   string value = 1 [(buf.validate.field).string.address = true];
-    //}
-    //```
+    // }
+    // ```
     bool address = 21 [(priv.field).cel = {
       id: "string.address",
       message: "value must be a valid hostname, or ip address",
       expression: "this.isHostname() || this.isIp()",
     }];
 
-    //`uuid` specifies that the field value must be a valid UUID as defined by
-    //[RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
-    //field value isn't a valid UUID, an error message will be generated.
+    // `uuid` specifies that the field value must be a valid UUID as defined by
+    // [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.2). If the
+    // field value isn't a valid UUID, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid UUID
+    // ```proto
+    // message MyString {
+    //   // value must be a valid UUID
     //   string value = 1 [(buf.validate.field).string.uuid = true];
-    //}
-    //```
+    // }
+    // ```
     bool uuid = 22 [(priv.field).cel = {
       id: "string.uuid",
       expression: "!this.matches('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$') ? 'value must be a valid UUID' : ''"
     }];
 
-    //`well_known_regex` specifies a common well-known pattern
-    //defined as a regex. If the field value doesn't match the well-known
-    //regex, an error message will be generated.
+    // `well_known_regex` specifies a common well-known pattern
+    // defined as a regex. If the field value doesn't match the well-known
+    // regex, an error message will be generated.
     //
-    //```proto
-    //message MyString {
-    //  // value must be a valid HTTP header value
+    // ```proto
+    // message MyString {
+    //   // value must be a valid HTTP header value
     //   string value = 1 [(buf.validate.field).string.well_known_regex = 2];
-    //}
-    //```
+    // }
+    // ```
     //
-    //#### KnownRegex
+    // #### KnownRegex
     //
-    //`well_known_regex` contains some well-known patterns.
+    // `well_known_regex` contains some well-known patterns.
     //
-    //| Name                          | Number | Description                               |
-    //|-------------------------------|--------|-------------------------------------------|
-    //| KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
-    //| KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
-    //| KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
+    // | Name                          | Number | Description                               |
+    // |-------------------------------|--------|-------------------------------------------|
+    // | KNOWN_REGEX_UNSPECIFIED       | 0      |                                           |
+    // | KNOWN_REGEX_HTTP_HEADER_NAME  | 1      | HTTP header name as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2)  |
+    // | KNOWN_REGEX_HTTP_HEADER_VALUE | 2      | HTTP header value as defined by [RFC 7230](https://tools.ietf.org/html/rfc7230#section-3.2.4) |
     KnownRegex well_known_regex = 24 [
       (priv.field).cel = {
         id: "string.well_known_regex.header_name"
@@ -2856,18 +2859,18 @@ message StringRules {
     ];
   }
 
-  //This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
-  //enable strict header validation. By default, this is true, and HTTP header
-  //validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
-  //validations that only disallow `\r\n\0` characters, which can be used to
-  //bypass header matching rules.
+  // This applies to regexes `HTTP_HEADER_NAME` and `HTTP_HEADER_VALUE` to
+  // enable strict header validation. By default, this is true, and HTTP header
+  // validations are [RFC-compliant](https://tools.ietf.org/html/rfc7230#section-3). Setting to false will enable looser
+  // validations that only disallow `\r\n\0` characters, which can be used to
+  // bypass header matching rules.
   //
-  //```proto
-  //message MyString {
+  // ```proto
+  // message MyString {
   //   // The field `value` must have be a valid HTTP headers, but not enforced with strict rules.
   //   string value = 1 [(buf.validate.field).string.strict = false];
-  //}
-  //```
+  // }
+  // ```
   optional bool strict = 25;
 }
 
@@ -2885,152 +2888,152 @@ enum KnownRegex {
 // BytesRules describe the constraints applied to `bytes` values. These rules
 // may also be applied to the `google.protobuf.BytesValue` Well-Known-Type.
 message BytesRules {
-  //`const` requires the field value to exactly match the specified bytes
-  //value. If the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified bytes
+  // value. If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  //  // value must be "\x01\x02\x03\x04"
+  // ```proto
+  // message MyBytes {
+  //   // value must be "\x01\x02\x03\x04"
   //   bytes value = 1 [(buf.validate.field).bytes.const = "\x01\x02\x03\x04"];
-  //}
-  //```
+  // }
+  // ```
   optional bytes const = 1 [(priv.field).cel = {
     id: "bytes.const",
     expression: "this != rules.const ? 'value must be %x'.format([rules.const]) : ''"
   }];
 
-  //`len` requires the field value to have the specified length in bytes.
-  //If the field value doesn't match, an error message is generated.
+  // `len` requires the field value to have the specified length in bytes.
+  // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  //      // value length must be 4 bytes.
-  //      optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value length must be 4 bytes.
+  //   optional bytes value = 1 [(buf.validate.field).bytes.len = 4];
+  // }
+  // ```
   optional uint64 len = 13 [(priv.field).cel = {
     id: "bytes.len",
     expression: "uint(this.size()) != rules.len ? 'value length must be %s bytes'.format([rules.len]) : ''"
   }];
 
-  //`min_len` requires the field value to have at least the specified minimum
-  //length in bytes.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `min_len` requires the field value to have at least the specified minimum
+  // length in bytes.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value length must be at least 2 bytes.
-  // optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value length must be at least 2 bytes.
+  //   optional bytes value = 1 [(buf.validate.field).bytes.min_len = 2];
+  // }
+  // ```
   optional uint64 min_len = 2 [(priv.field).cel = {
     id: "bytes.min_len",
     expression: "uint(this.size()) < rules.min_len ? 'value length must be at least %s bytes'.format([rules.min_len]) : ''"
   }];
 
-  //`max_len` requires the field value to have at most the specified maximum
-  //length in bytes.
-  //If the field value exceeds the requirement, an error message is generated.
+  // `max_len` requires the field value to have at most the specified maximum
+  // length in bytes.
+  // If the field value exceeds the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value must be at most 6 bytes.
-  // optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value must be at most 6 bytes.
+  //   optional bytes value = 1 [(buf.validate.field).bytes.max_len = 6];
+  // }
+  // ```
   optional uint64 max_len = 3 [(priv.field).cel = {
     id: "bytes.max_len",
     expression: "uint(this.size()) > rules.max_len ? 'value must be at most %s bytes'.format([rules.max_len]) : ''"
   }];
 
-  //`pattern` requires the field value to match the specified regular
-  //expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
-  //The value of the field must be valid UTF-8 or validation will fail with a
-  //runtime error.
-  //If the field value doesn't match the pattern, an error message is generated.
+  // `pattern` requires the field value to match the specified regular
+  // expression ([RE2 syntax](https://github.com/google/re2/wiki/Syntax)).
+  // The value of the field must be valid UTF-8 or validation will fail with a
+  // runtime error.
+  // If the field value doesn't match the pattern, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value must match regex pattern "^[a-zA-Z0-9]+$".
-  // optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value must match regex pattern "^[a-zA-Z0-9]+$".
+  //   optional bytes value = 1 [(buf.validate.field).bytes.pattern = "^[a-zA-Z0-9]+$"];
+  // }
+  // ```
   optional string pattern = 4 [(priv.field).cel = {
     id: "bytes.pattern",
     expression: "!string(this).matches(rules.pattern) ? 'value must match regex pattern `%s`'.format([rules.pattern]) : ''"
   }];
 
-  //`prefix` requires the field value to have the specified bytes at the
-  //beginning of the string.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `prefix` requires the field value to have the specified bytes at the
+  // beginning of the string.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  //// value does not have prefix \x01\x02
-  //optional bytes value = 1 [(buf.validate.field).bytes.prefix = "\x01\x02"];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value does not have prefix \x01\x02
+  //   optional bytes value = 1 [(buf.validate.field).bytes.prefix = "\x01\x02"];
+  // }
+  // ```
   optional bytes prefix = 5 [(priv.field).cel = {
     id: "bytes.prefix",
     expression: "!this.startsWith(rules.prefix) ? 'value does not have prefix %x'.format([rules.prefix]) : ''"
   }];
 
-  //`suffix` requires the field value to have the specified bytes at the end
-  //of the string.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `suffix` requires the field value to have the specified bytes at the end
+  // of the string.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value does not have suffix \x03\x04
-  // optional bytes value = 1 [(buf.validate.field).bytes.suffix = "\x03\x04"];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value does not have suffix \x03\x04
+  //   optional bytes value = 1 [(buf.validate.field).bytes.suffix = "\x03\x04"];
+  // }
+  // ```
   optional bytes suffix = 6 [(priv.field).cel = {
     id: "bytes.suffix",
     expression: "!this.endsWith(rules.suffix) ? 'value does not have suffix %x'.format([rules.suffix]) : ''"
   }];
 
-  //`contains` requires the field value to have the specified bytes anywhere in
-  //the string.
-  //If the field value doesn't meet the requirement, an error message is generated.
+  // `contains` requires the field value to have the specified bytes anywhere in
+  // the string.
+  // If the field value doesn't meet the requirement, an error message is generated.
   //
-  //```protobuf
-  //message MyBytes {
-  // // value does not contain \x02\x03
-  // optional bytes value = 1 [(buf.validate.field).bytes.contains = "\x02\x03"];
-  //}
-  //```
+  // ```protobuf
+  // message MyBytes {
+  //   // value does not contain \x02\x03
+  //   optional bytes value = 1 [(buf.validate.field).bytes.contains = "\x02\x03"];
+  // }
+  // ```
   optional bytes contains = 7 [(priv.field).cel = {
     id: "bytes.contains",
     expression: "!this.contains(rules.contains) ? 'value does not contain %x'.format([rules.contains]) : ''"
   }];
 
-  //`in` requires the field value to be equal to one of the specified
-  //values. If the field value doesn't match any of the specified values, an
-  //error message is generated.
+  // `in` requires the field value to be equal to one of the specified
+  // values. If the field value doesn't match any of the specified values, an
+  // error message is generated.
   //
-  //```protobuf
-  //message MyBytes {
-  // // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
-  // optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
-  //}
-  //```
+  // ```protobuf
+  // message MyBytes {
+  //   // value must in ["\x01\x02", "\x02\x03", "\x03\x04"]
+  //   optional bytes value = 1 [(buf.validate.field).bytes.in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+  // }
+  // ```
   repeated bytes in = 8 [(priv.field).cel = {
     id: "bytes.in",
     expression: "dyn(rules)['in'].size() > 0 && !(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''"
   }];
 
-  //`not_in` requires the field value to be not equal to any of the specified
-  //values.
-  //If the field value matches any of the specified values, an error message is
-  //generated.
+  // `not_in` requires the field value to be not equal to any of the specified
+  // values.
+  // If the field value matches any of the specified values, an error message is
+  // generated.
   //
-  //```proto
-  //message MyBytes {
-  // // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
-  // optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
-  //}
-  //```
+  // ```proto
+  // message MyBytes {
+  //   // value must not in ["\x01\x02", "\x02\x03", "\x03\x04"]
+  //   optional bytes value = 1 [(buf.validate.field).bytes.not_in = {"\x01\x02", "\x02\x03", "\x03\x04"}];
+  // }
+  // ```
   repeated bytes not_in = 9 [(priv.field).cel = {
     id: "bytes.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''"
@@ -3039,42 +3042,42 @@ message BytesRules {
   // WellKnown rules provide advanced constraints against common byte
   // patterns
   oneof well_known {
-    //`ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
-    //If the field value doesn't meet this constraint, an error message is generated.
+    // `ip` ensures that the field `value` is a valid IP address (v4 or v6) in byte format.
+    // If the field value doesn't meet this constraint, an error message is generated.
     //
-    //```proto
-    //message MyBytes {
-    // // value must be a valid IP address
-    // optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
-    //}
-    //```
+    // ```proto
+    // message MyBytes {
+    //   // value must be a valid IP address
+    //   optional bytes value = 1 [(buf.validate.field).bytes.ip = true];
+    // }
+    // ```
     bool ip = 10 [(priv.field).cel = {
       id: "bytes.ip",
       expression: "this.size() != 4 && this.size() != 16 ? 'value must be a valid IP address' : ''"
     }];
 
-    //`ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
-    //If the field value doesn't meet this constraint, an error message is generated.
+    // `ipv4` ensures that the field `value` is a valid IPv4 address in byte format.
+    // If the field value doesn't meet this constraint, an error message is generated.
     //
-    //```proto
-    //message MyBytes {
-    // // value must be a valid IPv4 address
-    // optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
-    //}
-    //```
+    // ```proto
+    // message MyBytes {
+    //   // value must be a valid IPv4 address
+    //   optional bytes value = 1 [(buf.validate.field).bytes.ipv4 = true];
+    // }
+    // ```
     bool ipv4 = 11 [(priv.field).cel = {
       id: "bytes.ipv4",
       expression: "this.size() != 4 ? 'value must be a valid IPv4 address' : ''"
     }];
 
-    //`ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
-    //If the field value doesn't meet this constraint, an error message is generated.
-    //```proto
-    //message MyBytes {
-    // // value must be a valid IPv6 address
-    // optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
-    //}
-    //```
+    // `ipv6` ensures that the field `value` is a valid IPv6 address in byte format.
+    // If the field value doesn't meet this constraint, an error message is generated.
+    // ```proto
+    // message MyBytes {
+    //   // value must be a valid IPv6 address
+    //   optional bytes value = 1 [(buf.validate.field).bytes.ipv6 = true];
+    // }
+    // ```
     bool ipv6 = 12 [(priv.field).cel = {
       id: "bytes.ipv6",
       expression: "this.size() != 16 ? 'value must be a valid IPv6 address' : ''"
@@ -3084,80 +3087,80 @@ message BytesRules {
 
 // EnumRules describe the constraints applied to `enum` values.
 message EnumRules {
-  //`const` requires the field value to exactly match the specified enum value.
-  //If the field value doesn't match, an error message is generated.
+  // `const` requires the field value to exactly match the specified enum value.
+  // If the field value doesn't match, an error message is generated.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must be exactly MY_ENUM_VALUE1.
+  // message MyMessage {
+  //   // The field `value` must be exactly MY_ENUM_VALUE1.
   //   MyEnum value = 1 [(buf.validate.field).enum.const = 1];
-  //}
-  //```
+  // }
+  // ```
   optional int32 const = 1 [(priv.field).cel = {
     id: "enum.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
 
-  //`defined_only` requires the field value to be one of the defined values for
+  // `defined_only` requires the field value to be one of the defined values for
   // this enum, failing on any undefined value.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must be a defined value of MyEnum.
+  // message MyMessage {
+  //   // The field `value` must be a defined value of MyEnum.
   //   MyEnum value = 1 [(buf.validate.field).enum.defined_only = true];
-  //}
-  //```
+  // }
+  // ```
   optional bool defined_only = 2;
 
-  //`in` requires the field value to be equal to one of the
+  // `in` requires the field value to be equal to one of the
   //specified enum values. If the field value doesn't match any of the
   //specified values, an error message is generated.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must be equal to one of the specified values.
+  // message MyMessage {
+  //   // The field `value` must be equal to one of the specified values.
   //   MyEnum value = 1 [(buf.validate.field).enum.in = {1, 2}];
-  //}
-  //```
+  // }
+  // ```
   repeated int32 in = 3 [(priv.field).cel = {
     id: "enum.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` requires the field value to be not equal to any of the
+  // `not_in` requires the field value to be not equal to any of the
   //specified enum values. If the field value matches one of the specified
-  //values, an error message is generated.
+  // values, an error message is generated.
   //
-  //```proto
-  //enum MyEnum {
-  //  MY_ENUM_UNSPECIFIED = 0;
-  //  MY_ENUM_VALUE1 = 1;
-  //  MY_ENUM_VALUE2 = 2;
-  //}
+  // ```proto
+  // enum MyEnum {
+  //   MY_ENUM_UNSPECIFIED = 0;
+  //   MY_ENUM_VALUE1 = 1;
+  //   MY_ENUM_VALUE2 = 2;
+  // }
   //
-  //message MyMessage {
-  //  // The field `value` must not be equal to any of the specified values.
+  // message MyMessage {
+  //   // The field `value` must not be equal to any of the specified values.
   //   MyEnum value = 1 [(buf.validate.field).enum.not_in = {1, 2}];
-  //}
-  //```
+  // }
+  // ```
   repeated int32 not_in = 4 [(priv.field).cel = {
     id: "enum.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -3166,95 +3169,97 @@ message EnumRules {
 
 // RepeatedRules describe the constraints applied to `repeated` values.
 message RepeatedRules {
-  //`min_items` requires that this field must contain at least the specified
-  //minimum number of items.
+  // `min_items` requires that this field must contain at least the specified
+  // minimum number of items.
   //
-  //```proto
-  //message MyRepeated {
-  //  // value must contain at least  2 items
-  //  repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
-  //}
-  //```
+  // Note that `min_items = 1` is equivalent to setting a field as `required`.
+  //
+  // ```proto
+  // message MyRepeated {
+  //   // value must contain at least  2 items
+  //   repeated string value = 1 [(buf.validate.field).repeated.min_items = 2];
+  // }
+  // ```
   optional uint64 min_items = 1 [(priv.field).cel = {
     id: "repeated.min_items"
     expression: "uint(this.size()) < rules.min_items ? 'value must contain at least %d item(s)'.format([rules.min_items]) : ''"
   }];
 
-  //`max_items` denotes that this field must not exceed a
-  //certain number of items as the upper limit. If the field contains more
-  //items than specified, an error message will be generated, requiring the
-  //field to maintain no more than the specified number of items.
+  // `max_items` denotes that this field must not exceed a
+  // certain number of items as the upper limit. If the field contains more
+  // items than specified, an error message will be generated, requiring the
+  // field to maintain no more than the specified number of items.
   //
-  //```proto
-  //message MyRepeated {
-  //  // value must contain no more than 3 item(s)
-  //  repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // value must contain no more than 3 item(s)
+  //   repeated string value = 1 [(buf.validate.field).repeated.max_items = 3];
+  // }
+  // ```
   optional uint64 max_items = 2 [(priv.field).cel = {
     id: "repeated.max_items"
     expression: "uint(this.size()) > rules.max_items ? 'value must contain no more than %s item(s)'.format([rules.max_items]) : ''"
   }];
 
-  //`unique` indicates that all elements in this field must
-  //be unique. This constraint is strictly applicable to scalar and enum
-  //types, with message types not being supported.
+  // `unique` indicates that all elements in this field must
+  // be unique. This constraint is strictly applicable to scalar and enum
+  // types, with message types not being supported.
   //
-  //```proto
-  //message MyRepeated {
-  //  // repeated value must contain unique items
-  //  repeated string value = 1 [(buf.validate.field).repeated.unique = true];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // repeated value must contain unique items
+  //   repeated string value = 1 [(buf.validate.field).repeated.unique = true];
+  // }
+  // ```
   optional bool unique = 3 [(priv.field).cel = {
     id: "repeated.unique"
     message: "repeated value must contain unique items"
     expression: "this.unique()"
   }];
 
-  //`items` details the constraints to be applied to each item
-  //in the field. Even for repeated message fields, validation is executed
-  //against each item unless skip is explicitly specified.
+  // `items` details the constraints to be applied to each item
+  // in the field. Even for repeated message fields, validation is executed
+  // against each item unless skip is explicitly specified.
   //
-  //```proto
-  //message MyRepeated {
-  //  // The items in the field `value` must follow the specified constraints.
-  //  repeated string value = 1 [(buf.validate.field).repeated.items = {
-  //    string: {
-  //      min_len: 3
-  //      max_len: 10
-  //    }
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyRepeated {
+  //   // The items in the field `value` must follow the specified constraints.
+  //   repeated string value = 1 [(buf.validate.field).repeated.items = {
+  //     string: {
+  //       min_len: 3
+  //       max_len: 10
+  //     }
+  //   }];
+  // }
+  // ```
   optional FieldConstraints items = 4;
 }
 
 // MapRules describe the constraints applied to `map` values.
 message MapRules {
   //Specifies the minimum number of key-value pairs allowed. If the field has
-  //fewer key-value pairs than specified, an error message is generated.
+  // fewer key-value pairs than specified, an error message is generated.
   //
-  //```proto
-  //message MyMap {
-  //  // The field `value` must have at least 2 key-value pairs.
-  //  map<string, string> value = 1 [(buf.validate.field).map.min_pairs = 2];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The field `value` must have at least 2 key-value pairs.
+  //   map<string, string> value = 1 [(buf.validate.field).map.min_pairs = 2];
+  // }
+  // ```
   optional uint64 min_pairs = 1 [(priv.field).cel = {
     id: "map.min_pairs"
     expression: "uint(this.size()) < rules.min_pairs ? 'map must be at least %d entries'.format([rules.min_pairs]) : ''"
   }];
 
   //Specifies the maximum number of key-value pairs allowed. If the field has
-  //more key-value pairs than specified, an error message is generated.
+  // more key-value pairs than specified, an error message is generated.
   //
-  //```proto
-  //message MyMap {
-  //  // The field `value` must have at most 3 key-value pairs.
-  //  map<string, string> value = 1 [(buf.validate.field).map.max_pairs = 3];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The field `value` must have at most 3 key-value pairs.
+  //   map<string, string> value = 1 [(buf.validate.field).map.max_pairs = 3];
+  // }
+  // ```
   optional uint64 max_pairs = 2 [(priv.field).cel = {
     id: "map.max_pairs"
     expression: "uint(this.size()) > rules.max_pairs ? 'map must be at most %d entries'.format([rules.max_pairs]) : ''"
@@ -3262,89 +3267,89 @@ message MapRules {
 
   //Specifies the constraints to be applied to each key in the field.
   //
-  //```proto
-  //message MyMap {
-  //  // The keys in the field `value` must follow the specified constraints.
-  //  map<string, string> value = 1 [(buf.validate.field).map.keys = {
-  //    string: {
-  //      min_len: 3
-  //      max_len: 10
-  //    }
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The keys in the field `value` must follow the specified constraints.
+  //   map<string, string> value = 1 [(buf.validate.field).map.keys = {
+  //     string: {
+  //       min_len: 3
+  //       max_len: 10
+  //     }
+  //   }];
+  // }
+  // ```
   optional FieldConstraints keys = 4;
 
   //Specifies the constraints to be applied to the value of each key in the
-  //field. Message values will still have their validations evaluated unless
+  // field. Message values will still have their validations evaluated unless
   //skip is specified here.
   //
-  //```proto
-  //message MyMap {
-  //  // The values in the field `value` must follow the specified constraints.
-  //  map<string, string> value = 1 [(buf.validate.field).map.values = {
-  //    string: {
-  //      min_len: 5
-  //      max_len: 20
-  //    }
-  //  }];
-  //}
-  //```
+  // ```proto
+  // message MyMap {
+  //   // The values in the field `value` must follow the specified constraints.
+  //   map<string, string> value = 1 [(buf.validate.field).map.values = {
+  //     string: {
+  //       min_len: 5
+  //       max_len: 20
+  //     }
+  //   }];
+  // }
+  // ```
   optional FieldConstraints values = 5;
 }
 
 // AnyRules describe constraints applied exclusively to the `google.protobuf.Any` well-known type.
 message AnyRules {
-  //`in` requires the field's `type_url` to be equal to one of the
+  // `in` requires the field's `type_url` to be equal to one of the
   //specified values. If it doesn't match any of the specified values, an error
-  //message is generated.
+  // message is generated.
   //
-  //```proto
-  //message MyAny {
-  //  //  The `value` field must have a `type_url` equal to one of the specified values.
+  // ```proto
+  // message MyAny {
+  //   //  The `value` field must have a `type_url` equal to one of the specified values.
   //   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
-  //}
-  //```
+  // }
+  // ```
   repeated string in = 2;
 
   // requires the field's type_url to be not equal to any of the specified values. If it matches any of the specified values, an error message is generated.
   //
-  //```proto
-  //message MyAny {
-  //  // The field `value` must not have a `type_url` equal to any of the specified values.
+  // ```proto
+  // message MyAny {
+  //   // The field `value` must not have a `type_url` equal to any of the specified values.
   //   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
-  //}
-  //```
+  // }
+  // ```
   repeated string not_in = 3;
 }
 
 // DurationRules describe the constraints applied exclusively to the `google.protobuf.Duration` well-known type.
 message DurationRules {
-  //`const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
-  //If the field's value deviates from the specified value, an error message
-  //will be generated.
+  // `const` dictates that the field must match the specified value of the `google.protobuf.Duration` type exactly.
+  // If the field's value deviates from the specified value, an error message
+  // will be generated.
   //
-  //```proto
-  //message MyDuration {
-  //  // value must equal 5s
+  // ```proto
+  // message MyDuration {
+  //   // value must equal 5s
   //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.const = "5s"];
-  //}
-  //```
+  // }
+  // ```
   optional google.protobuf.Duration const = 2 [(priv.field).cel = {
     id: "duration.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
   }];
   oneof less_than {
-    //`lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
-    //exclusive. If the field's value is greater than or equal to the specified
-    //value, an error message will be generated.
+    // `lt` stipulates that the field must be less than the specified value of the `google.protobuf.Duration` type,
+    // exclusive. If the field's value is greater than or equal to the specified
+    // value, an error message will be generated.
     //
-    //```proto
-    //message MyDuration {
-    //  // value must be less than 5s
+    // ```proto
+    // message MyDuration {
+    //   // value must be less than 5s
     //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lt = "5s"];
-    //}
-    //```
+    // }
+    // ```
     google.protobuf.Duration lt = 3 [(priv.field).cel = {
       id: "duration.lt",
       expression:
@@ -3352,16 +3357,16 @@ message DurationRules {
         "? 'value must be less than %s'.format([rules.lt]) : ''"
     }];
 
-    //`lte` indicates that the field must be less than or equal to the specified
-    //value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
-    //an error message will be generated.
+    // `lte` indicates that the field must be less than or equal to the specified
+    // value of the `google.protobuf.Duration` type, inclusive. If the field's value is greater than the specified value,
+    // an error message will be generated.
     //
-    //```proto
-    //message MyDuration {
-    //  // value must be less than or equal to 10s
+    // ```proto
+    // message MyDuration {
+    //   // value must be less than or equal to 10s
     //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.lte = "10s"];
-    //}
-    //```
+    // }
+    // ```
     google.protobuf.Duration lte = 4 [(priv.field).cel = {
       id: "duration.lte",
       expression:
@@ -3376,18 +3381,18 @@ message DurationRules {
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyDuration {
-    //  // duration must be greater than 5s [duration.gt]
-    //  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
+    // ```proto
+    // message MyDuration {
+    //   // duration must be greater than 5s [duration.gt]
+    //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.gt = { seconds: 5 }];
     //
-    //  // duration must be greater than 5s and less than 10s [duration.gt_lt]
-    //  google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
+    //   // duration must be greater than 5s and less than 10s [duration.gt_lt]
+    //   google.protobuf.Duration another_value = 2 [(buf.validate.field).duration = { gt: { seconds: 5 }, lt: { seconds: 10 } }];
     //
-    //  // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
-    //  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
-    //}
-    //```
+    //   // duration must be greater than 10s or less than 5s [duration.gt_lt_exclusive]
+    //   google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gt: { seconds: 10 }, lt: { seconds: 5 } }];
+    // }
+    // ```
     google.protobuf.Duration gt = 5 [
       (priv.field).cel = {
         id: "duration.gt",
@@ -3427,8 +3432,8 @@ message DurationRules {
     // be outside the specified range. If the field value doesn't meet the
     // required conditions, an error message is generated.
     //
-    //```proto
-    //message MyDuration {
+    // ```proto
+    // message MyDuration {
     //  // duration must be greater than or equal to 5s [duration.gte]
     //  google.protobuf.Duration value = 1 [(buf.validate.field).duration.gte = { seconds: 5 }];
     //
@@ -3437,8 +3442,8 @@ message DurationRules {
     //
     //  // duration must be greater than or equal to 10s or less than 5s [duration.gte_lt_exclusive]
     //  google.protobuf.Duration other_value = 3 [(buf.validate.field).duration = { gte: { seconds: 10 }, lt: { seconds: 5 } }];
-    //}
-    //```
+    // }
+    // ```
     google.protobuf.Duration gte = 6 [
       (priv.field).cel = {
         id: "duration.gte",
@@ -3473,32 +3478,32 @@ message DurationRules {
     ];
   }
 
-  //`in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
-  //If the field's value doesn't correspond to any of the specified values,
-  //an error message will be generated.
+  // `in` asserts that the field must be equal to one of the specified values of the `google.protobuf.Duration` type.
+  // If the field's value doesn't correspond to any of the specified values,
+  // an error message will be generated.
   //
-  //```proto
-  //message MyDuration {
-  //  // value must be in list [1s, 2s, 3s]
+  // ```proto
+  // message MyDuration {
+  //   // value must be in list [1s, 2s, 3s]
   //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.in = ["1s", "2s", "3s"]];
-  //}
-  //```
+  // }
+  // ```
   repeated google.protobuf.Duration in = 7 [(priv.field).cel = {
     id: "duration.in",
     expression: "!(this in dyn(rules)['in']) ? 'value must be in list %s'.format([dyn(rules)['in']]) : ''",
   }];
 
-  //`not_in` denotes that the field must not be equal to
-  //any of the specified values of the `google.protobuf.Duration` type.
-  //If the field's value matches any of these values, an error message will be
-  //generated.
+  // `not_in` denotes that the field must not be equal to
+  // any of the specified values of the `google.protobuf.Duration` type.
+  // If the field's value matches any of these values, an error message will be
+  // generated.
   //
-  //```proto
-  //message MyDuration {
-  //  // value must not be in list [1s, 2s, 3s]
+  // ```proto
+  // message MyDuration {
+  //   // value must not be in list [1s, 2s, 3s]
   //   google.protobuf.Duration value = 1 [(buf.validate.field).duration.not_in = ["1s", "2s", "3s"]];
-  //}
-  //```
+  // }
+  // ```
   repeated google.protobuf.Duration not_in = 8 [(priv.field).cel = {
     id: "duration.not_in",
     expression: "this in rules.not_in ? 'value must not be in list %s'.format([rules.not_in]) : ''",
@@ -3507,14 +3512,14 @@ message DurationRules {
 
 // TimestampRules describe the constraints applied exclusively to the `google.protobuf.Timestamp` well-known type.
 message TimestampRules {
-  //`const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
+  // `const` dictates that this field, of the `google.protobuf.Timestamp` type, must exactly match the specified value. If the field value doesn't correspond to the specified timestamp, an error message will be generated.
   //
-  //```proto
-  //message MyTimestamp {
-  //  // value must equal 2023-05-03T10:00:00Z
+  // ```proto
+  // message MyTimestamp {
+  //   // value must equal 2023-05-03T10:00:00Z
   //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.const = {seconds: 1727998800}];
-  //}
-  //```
+  // }
+  // ```
   optional google.protobuf.Timestamp const = 2 [(priv.field).cel = {
     id: "timestamp.const",
     expression: "this != rules.const ? 'value must equal %s'.format([rules.const]) : ''",
@@ -3550,38 +3555,38 @@ message TimestampRules {
         "? 'value must be less than or equal to %s'.format([rules.lte]) : ''"
     }];
 
-    //`lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
+    // `lt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be less than the current time. `lt_now` can only be used with the `within` rule.
     //
-    //```proto
-    //message MyTimestamp {
+    // ```proto
+    // message MyTimestamp {
     //  // value must be less than now
     //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.lt_now = true];
-    //}
-    //```
+    // }
+    // ```
     bool lt_now = 7 [(priv.field).cel = {
       id: "timestamp.lt_now",
       expression: "this > now ? 'value must be less than now' : ''"
     }];
   }
   oneof greater_than {
-    //`gt` requires the timestamp field value to be greater than the specified
+    // `gt` requires the timestamp field value to be greater than the specified
     // value (exclusive). If the value of `gt` is larger than a specified `lt`
     // or `lte`, the range is reversed, and the field value must be outside the
     // specified range. If the field value doesn't meet the required conditions,
     // an error message is generated.
     //
-    //```proto
-    //message MyTimestamp {
-    //  // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
-    //  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
+    // ```proto
+    // message MyTimestamp {
+    //   // timestamp must be greater than '2023-01-01T00:00:00Z' [timestamp.gt]
+    //   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gt = { seconds: 1672444800 }];
     //
-    //  // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
-    //  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+    //   // timestamp must be greater than '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gt_lt]
+    //   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gt: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
     //
-    //  // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
-    //  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-    //}
-    //```
+    //   // timestamp must be greater than '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gt_lt_exclusive]
+    //   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gt: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+    // }
+    // ```
     google.protobuf.Timestamp gt = 5 [
       (priv.field).cel = {
         id: "timestamp.gt",
@@ -3615,24 +3620,24 @@ message TimestampRules {
       }
     ];
 
-    //`gte` requires the timestamp field value to be greater than or equal to the
+    // `gte` requires the timestamp field value to be greater than or equal to the
     // specified value (exclusive). If the value of `gte` is larger than a
     // specified `lt` or `lte`, the range is reversed, and the field value
     // must be outside the specified range. If the field value doesn't meet
     // the required conditions, an error message is generated.
     //
-    //```proto
-    //message MyTimestamp {
-    //  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
-    //  google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
+    // ```proto
+    // message MyTimestamp {
+    //   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' [timestamp.gte]
+    //   google.protobuf.Timestamp value = 1 [(buf.validate.field).timestamp.gte = { seconds: 1672444800 }];
     //
-    //  // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
-    //  google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
+    //   // timestamp must be greater than or equal to '2023-01-01T00:00:00Z' and less than '2023-01-02T00:00:00Z' [timestamp.gte_lt]
+    //   google.protobuf.Timestamp another_value = 2 [(buf.validate.field).timestamp = { gte: { seconds: 1672444800 }, lt: { seconds: 1672531200 } }];
     //
-    //  // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
-    //  google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
-    //}
-    //```
+    //   // timestamp must be greater than or equal to '2023-01-02T00:00:00Z' or less than '2023-01-01T00:00:00Z' [timestamp.gte_lt_exclusive]
+    //   google.protobuf.Timestamp other_value = 3 [(buf.validate.field).timestamp = { gte: { seconds: 1672531200 }, lt: { seconds: 1672444800 } }];
+    // }
+    // ```
     google.protobuf.Timestamp gte = 6 [
       (priv.field).cel = {
         id: "timestamp.gte",
@@ -3666,14 +3671,14 @@ message TimestampRules {
       }
     ];
 
-    //`gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
+    // `gt_now` specifies that this field, of the `google.protobuf.Timestamp` type, must be greater than the current time. `gt_now` can only be used with the `within` rule.
     //
-    //```proto
-    //message MyTimestamp {
-    //  // value must be greater than now
+    // ```proto
+    // message MyTimestamp {
+    //   // value must be greater than now
     //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.gt_now = true];
-    //}
-    //```
+    // }
+    // ```
     bool gt_now = 8 [(priv.field).cel = {
       id: "timestamp.gt_now",
       expression: "this < now ? 'value must be greater than now' : ''"
@@ -3682,12 +3687,12 @@ message TimestampRules {
 
   // `within` specifies that this field, of the `google.protobuf.Timestamp` type, must be within the specified duration of the current time. If the field value isn't within the duration, an error message is generated.
   //
-  //```proto
-  //message MyTimestamp {
-  //  // value must be within 1 hour of now
+  // ```proto
+  // message MyTimestamp {
+  //   // value must be within 1 hour of now
   //   google.protobuf.Timestamp created_at = 1 [(buf.validate.field).timestamp.within = {seconds: 3600}];
-  //}
-  //```
+  // }
+  // ```
   optional google.protobuf.Duration within = 9 [(priv.field).cel = {
     id: "timestamp.within",
     expression: "this < now-rules.within || this > now+rules.within ? 'value must be within %s of now'.format([rules.within]) : ''"

--- a/src/test/resources/proto/buf.lock
+++ b/src/test/resources/proto/buf.lock
@@ -4,5 +4,5 @@ deps:
   - remote: buf.build
     owner: bufbuild
     repository: protovalidate
-    commit: 63dfe56cc2c44cffa4815366ba7a99c0
-    digest: shake256:5a8a9856b92bf37171d45ccbe59fc48ea755cd682317b088cdf93e8e797ecf54039e012ece9a17084bb676e70c2e090296b2790782ebdbbedc7514e9b543e6bf
+    commit: 0de7443d03cf41228f8a9790b12b417e
+    digest: shake256:3c0676a73cef06439c107cb9560627354815adbc254976f807d645de7e2c1bf19d0438d5d56d5bc92465377e0d9315951e986fc6ced2871e450534b2b8c953b0

--- a/src/test/resources/proto/buf.yaml
+++ b/src/test/resources/proto/buf.yaml
@@ -3,7 +3,7 @@ breaking:
   use:
     - FILE
 deps:
-  - buf.build/bufbuild/protovalidate:v0.4.3
+  - buf.build/bufbuild/protovalidate:v0.4.4
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
Update the protovalidate buf module to v0.4.4. Use automatic versioning of assets based on the last tag number (for local development or if we decide to ever publish snapshot versions).