### PR TITLE
Update README violations to getViolations()

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ public class Main {
         ValidationResult result = validator.validate(transaction);
 
         // Check if there are any validation violations
-        if (result.violations.isEmpty()) {
+        if (result.getViolations().isEmpty()) {
             // No violations, validation successful
             System.out.println("Validation succeeded");
         } else {


### PR DESCRIPTION
First time setting up protovalidate-java, following the example given in the readme `if (result.violations.isEmpty()) {`
brings up the following error:
```
violations has private access in build.buf.protovalidate.ValidationResult
```
Can fix by modifying to `if (result.getViolations().isEmpty()) {`
