### PR TITLE
Jrinehart/tcn 2782 protovalidate java custom rules cannot use repeated nested

### DIFF
--- a/src/main/java/build/buf/protovalidate/EvaluatorBuilder.java
+++ b/src/main/java/build/buf/protovalidate/EvaluatorBuilder.java
@@ -334,7 +334,6 @@ class EvaluatorBuilder {
         ValueEvaluator valueEvaluatorEval)
         throws CompilationException {
       List<Constraint> constraintsCelList = fieldConstraints.getCelList();
-      boolean forItems = valueEvaluatorEval.hasNestedRule();
       if (constraintsCelList.isEmpty()) {
         return;
       }
@@ -349,7 +348,8 @@ class EvaluatorBuilder {
                   EnvOption.declarations(
                       Decls.newVar(
                           Variable.THIS_NAME,
-                          DescriptorMappings.getCELType(fieldDescriptor, forItems))));
+                          DescriptorMappings.getCELType(
+                              fieldDescriptor, valueEvaluatorEval.hasNestedRule()))));
         } catch (InvalidProtocolBufferException e) {
           throw new CompilationException("field descriptor type is invalid " + e.getMessage(), e);
         }

--- a/src/main/java/build/buf/protovalidate/EvaluatorBuilder.java
+++ b/src/main/java/build/buf/protovalidate/EvaluatorBuilder.java
@@ -270,7 +270,7 @@ class EvaluatorBuilder {
         FieldConstraints fieldConstraints,
         ValueEvaluator valueEvaluatorEval)
         throws CompilationException {
-      if (valueEvaluatorEval.getNestedRule() != null && shouldIgnoreEmpty(fieldConstraints)) {
+      if (valueEvaluatorEval.hasNestedRule() && shouldIgnoreEmpty(fieldConstraints)) {
         valueEvaluatorEval.setIgnoreEmpty(zeroValue(fieldDescriptor, true));
       }
     }
@@ -334,6 +334,7 @@ class EvaluatorBuilder {
         ValueEvaluator valueEvaluatorEval)
         throws CompilationException {
       List<Constraint> constraintsCelList = fieldConstraints.getCelList();
+      boolean forItems = valueEvaluatorEval.hasNestedRule();
       if (constraintsCelList.isEmpty()) {
         return;
       }
@@ -348,7 +349,7 @@ class EvaluatorBuilder {
                   EnvOption.declarations(
                       Decls.newVar(
                           Variable.THIS_NAME,
-                          Decls.newObjectType(fieldDescriptor.getMessageType().getFullName()))));
+                          DescriptorMappings.getCELType(fieldDescriptor, forItems))));
         } catch (InvalidProtocolBufferException e) {
           throw new CompilationException("field descriptor type is invalid " + e.getMessage(), e);
         }
@@ -376,7 +377,7 @@ class EvaluatorBuilder {
       if (fieldDescriptor.getJavaType() != FieldDescriptor.JavaType.MESSAGE
           || shouldSkip(fieldConstraints)
           || fieldDescriptor.isMapField()
-          || (fieldDescriptor.isRepeated() && valueEvaluatorEval.getNestedRule() == null)) {
+          || (fieldDescriptor.isRepeated() && !valueEvaluatorEval.hasNestedRule())) {
         return;
       }
       Evaluator embedEval =
@@ -393,7 +394,7 @@ class EvaluatorBuilder {
       if (fieldDescriptor.getJavaType() != FieldDescriptor.JavaType.MESSAGE
           || shouldSkip(fieldConstraints)
           || fieldDescriptor.isMapField()
-          || (fieldDescriptor.isRepeated() && valueEvaluatorEval.getNestedRule() == null)) {
+          || (fieldDescriptor.isRepeated() && !valueEvaluatorEval.hasNestedRule())) {
         return;
       }
       FieldDescriptor expectedWrapperDescriptor =
@@ -418,7 +419,7 @@ class EvaluatorBuilder {
         throws CompilationException {
       List<CompiledProgram> compile =
           constraintCache.compile(
-              fieldDescriptor, fieldConstraints, valueEvaluatorEval.getNestedRule() != null);
+              fieldDescriptor, fieldConstraints, valueEvaluatorEval.hasNestedRule());
       if (compile.isEmpty()) {
         return;
       }
@@ -429,7 +430,7 @@ class EvaluatorBuilder {
         FieldDescriptor fieldDescriptor,
         FieldConstraints fieldConstraints,
         ValueEvaluator valueEvaluatorEval) {
-      if ((fieldDescriptor.isRepeated() && valueEvaluatorEval.getNestedRule() == null)
+      if ((fieldDescriptor.isRepeated() && !valueEvaluatorEval.hasNestedRule())
           || fieldDescriptor.getJavaType() != FieldDescriptor.JavaType.MESSAGE
           || !fieldDescriptor.getMessageType().getFullName().equals("google.protobuf.Any")) {
         return;
@@ -484,7 +485,7 @@ class EvaluatorBuilder {
         throws CompilationException {
       if (fieldDescriptor.isMapField()
           || !fieldDescriptor.isRepeated()
-          || valueEvaluatorEval.getNestedRule() != null) {
+          || valueEvaluatorEval.hasNestedRule()) {
         return;
       }
       ListEvaluator listEval = new ListEvaluator(valueEvaluatorEval);

--- a/src/main/java/build/buf/protovalidate/ValueEvaluator.java
+++ b/src/main/java/build/buf/protovalidate/ValueEvaluator.java
@@ -59,6 +59,10 @@ class ValueEvaluator implements Evaluator {
     return nestedRule;
   }
 
+  public boolean hasNestedRule() {
+    return this.nestedRule != null;
+  }
+
   @Override
   public boolean tautology() {
     return evaluators.isEmpty();

--- a/src/test/java/build/buf/protovalidate/ValidatorCelExpressionTest.java
+++ b/src/test/java/build/buf/protovalidate/ValidatorCelExpressionTest.java
@@ -27,66 +27,6 @@ import org.junit.jupiter.api.Test;
  * This test verifies that custom (CEL-based) field and/or message constraints evaluate as expected.
  */
 public class ValidatorCelExpressionTest {
-  /*
-  @Test
-  public void testRepeatedNestedFieldCelExpression() throws Exception {
-    // Nested message wrapping the int 1
-    com.example.imports.validationtest.ExampleNestedIntMessage one =
-        com.example.imports.validationtest.ExampleNestedIntMessage.newBuilder()
-            .setIntValue(1)
-            .build();
-
-    // Nested message wrapping the int 2
-    com.example.imports.validationtest.ExampleNestedIntMessage two =
-        com.example.imports.validationtest.ExampleNestedIntMessage.newBuilder()
-            .setIntValue(2)
-            .build();
-
-    // Create a valid message (1, 2)
-    com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage validMsg =
-        com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage.newBuilder()
-            .addAllShouldBeUnique(Arrays.asList(one, two))
-            .build();
-
-    // Create an invalid message (1, 1)
-    com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage invalidMsg =
-        com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage.newBuilder()
-            .addAllShouldBeUnique(Arrays.asList(one, one))
-            .build();
-
-    // Build a model of the expected violation
-    Violation expectedViolation =
-        Violation.newBuilder()
-            .setField(
-                FieldPath.newBuilder()
-                    .addElements(
-                        FieldPathUtils.fieldPathElement(
-                            invalidMsg.getDescriptorForType().findFieldByName("should_be_unique"))))
-            .setRule(
-                FieldPath.newBuilder()
-                    .addElements(
-                        FieldPathUtils.fieldPathElement(
-                                FieldConstraints.getDescriptor()
-                                    .findFieldByNumber(FieldConstraints.CEL_FIELD_NUMBER))
-                            .toBuilder()
-                            .setIndex(0)
-                            .build()))
-            .setConstraintId("unique.message.int_values")
-            .setMessage("all nested message int_value values should be unique")
-            .build();
-
-    Validator validator = new Validator();
-
-    // Valid message checks
-    ValidationResult validResult = validator.validate(validMsg);
-    assertThat(validResult.isSuccess()).isTrue();
-
-    // Invalid message checks
-    ValidationResult invalidResult = validator.validate(invalidMsg);
-    assertThat(invalidResult.isSuccess()).isFalse();
-    assertThat(invalidResult.toProto().getViolationsList()).containsExactly(expectedViolation);
-  }
-    */
 
   @Test
   public void testFieldExpressionRepeatedMessage() throws Exception {

--- a/src/test/java/build/buf/protovalidate/ValidatorCelExpressionTest.java
+++ b/src/test/java/build/buf/protovalidate/ValidatorCelExpressionTest.java
@@ -1,0 +1,220 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build.buf.protovalidate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import build.buf.validate.FieldConstraints;
+import build.buf.validate.FieldPath;
+import build.buf.validate.Violation;
+import com.example.imports.buf.validate.RepeatedRules;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test verifies that custom (CEL-based) field and/or message constraints evaluate as expected.
+ */
+public class ValidatorCelExpressionTest {
+  /*
+  @Test
+  public void testRepeatedNestedFieldCelExpression() throws Exception {
+    // Nested message wrapping the int 1
+    com.example.imports.validationtest.ExampleNestedIntMessage one =
+        com.example.imports.validationtest.ExampleNestedIntMessage.newBuilder()
+            .setIntValue(1)
+            .build();
+
+    // Nested message wrapping the int 2
+    com.example.imports.validationtest.ExampleNestedIntMessage two =
+        com.example.imports.validationtest.ExampleNestedIntMessage.newBuilder()
+            .setIntValue(2)
+            .build();
+
+    // Create a valid message (1, 2)
+    com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage validMsg =
+        com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage.newBuilder()
+            .addAllShouldBeUnique(Arrays.asList(one, two))
+            .build();
+
+    // Create an invalid message (1, 1)
+    com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage invalidMsg =
+        com.example.imports.validationtest.ExampleCelExpressionRepeatedNestedMessage.newBuilder()
+            .addAllShouldBeUnique(Arrays.asList(one, one))
+            .build();
+
+    // Build a model of the expected violation
+    Violation expectedViolation =
+        Violation.newBuilder()
+            .setField(
+                FieldPath.newBuilder()
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                            invalidMsg.getDescriptorForType().findFieldByName("should_be_unique"))))
+            .setRule(
+                FieldPath.newBuilder()
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                                FieldConstraints.getDescriptor()
+                                    .findFieldByNumber(FieldConstraints.CEL_FIELD_NUMBER))
+                            .toBuilder()
+                            .setIndex(0)
+                            .build()))
+            .setConstraintId("unique.message.int_values")
+            .setMessage("all nested message int_value values should be unique")
+            .build();
+
+    Validator validator = new Validator();
+
+    // Valid message checks
+    ValidationResult validResult = validator.validate(validMsg);
+    assertThat(validResult.isSuccess()).isTrue();
+
+    // Invalid message checks
+    ValidationResult invalidResult = validator.validate(invalidMsg);
+    assertThat(invalidResult.isSuccess()).isFalse();
+    assertThat(invalidResult.toProto().getViolationsList()).containsExactly(expectedViolation);
+  }
+    */
+
+  @Test
+  public void testFieldExpressionRepeatedMessage() throws Exception {
+    // Nested message wrapping the int 1
+    com.example.imports.validationtest.FieldExpressionRepeatedMessage.Msg one =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessage.Msg.newBuilder()
+            .setA(1)
+            .build();
+
+    // Nested message wrapping the int 2
+    com.example.imports.validationtest.FieldExpressionRepeatedMessage.Msg two =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessage.Msg.newBuilder()
+            .setA(2)
+            .build();
+
+    // Create a valid message (1, 1)
+    com.example.imports.validationtest.FieldExpressionRepeatedMessage validMsg =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessage.newBuilder()
+            .addAllVal(Arrays.asList(one, one))
+            .build();
+
+    // Create an invalid message (1, 2, 1)
+    com.example.imports.validationtest.FieldExpressionRepeatedMessage invalidMsg =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessage.newBuilder()
+            .addAllVal(Arrays.asList(one, two, one))
+            .build();
+
+    // Build a model of the expected violation
+    Violation expectedViolation =
+        Violation.newBuilder()
+            .setField(
+                FieldPath.newBuilder()
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                                invalidMsg.getDescriptorForType().findFieldByName("val"))
+                            .toBuilder()
+                            .build()))
+            .setRule(
+                FieldPath.newBuilder()
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                                FieldConstraints.getDescriptor()
+                                    .findFieldByNumber(FieldConstraints.CEL_FIELD_NUMBER))
+                            .toBuilder()
+                            .setIndex(0)
+                            .build()))
+            .setConstraintId("field_expression.repeated.message")
+            .setMessage("test message field_expression.repeated.message")
+            .build();
+
+    Validator validator = new Validator();
+
+    // Valid message checks
+    ValidationResult validResult = validator.validate(validMsg);
+    assertThat(validResult.isSuccess()).isTrue();
+
+    // Invalid message checks
+    ValidationResult invalidResult = validator.validate(invalidMsg);
+    assertThat(invalidResult.isSuccess()).isFalse();
+    assertThat(invalidResult.toProto().getViolationsList()).containsExactly(expectedViolation);
+  }
+
+  @Test
+  public void testFieldExpressionRepeatedMessageItems() throws Exception {
+    // Nested message wrapping the int 1
+    com.example.imports.validationtest.FieldExpressionRepeatedMessageItems.Msg one =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessageItems.Msg.newBuilder()
+            .setA(1)
+            .build();
+
+    // Nested message wrapping the int 2
+    com.example.imports.validationtest.FieldExpressionRepeatedMessageItems.Msg two =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessageItems.Msg.newBuilder()
+            .setA(2)
+            .build();
+
+    // Create a valid message (1, 1)
+    com.example.imports.validationtest.FieldExpressionRepeatedMessageItems validMsg =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessageItems.newBuilder()
+            .addAllVal(Arrays.asList(one, one))
+            .build();
+
+    // Create an invalid message (1, 2, 1)
+    com.example.imports.validationtest.FieldExpressionRepeatedMessageItems invalidMsg =
+        com.example.imports.validationtest.FieldExpressionRepeatedMessageItems.newBuilder()
+            .addAllVal(Arrays.asList(one, two, one))
+            .build();
+
+    // Build a model of the expected violation
+    Violation expectedViolation =
+        Violation.newBuilder()
+            .setField(
+                FieldPath.newBuilder()
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                                invalidMsg.getDescriptorForType().findFieldByName("val"))
+                            .toBuilder()
+                            .setIndex(1)
+                            .build()))
+            .setRule(
+                FieldPath.newBuilder()
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                            FieldConstraints.getDescriptor()
+                                .findFieldByNumber(FieldConstraints.REPEATED_FIELD_NUMBER)))
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                            RepeatedRules.getDescriptor().findFieldByName("items")))
+                    .addElements(
+                        FieldPathUtils.fieldPathElement(
+                                FieldConstraints.getDescriptor()
+                                    .findFieldByNumber(FieldConstraints.CEL_FIELD_NUMBER))
+                            .toBuilder()
+                            .setIndex(0)
+                            .build()))
+            .setConstraintId("field_expression.repeated.message.items")
+            .setMessage("test message field_expression.repeated.message.items")
+            .build();
+
+    Validator validator = new Validator();
+
+    // Valid message checks
+    ValidationResult validResult = validator.validate(validMsg);
+    assertThat(validResult.isSuccess()).isTrue();
+
+    // Invalid message checks
+    ValidationResult invalidResult = validator.validate(invalidMsg);
+    assertThat(invalidResult.isSuccess()).isFalse();
+    assertThat(invalidResult.toProto().getViolationsList()).containsExactly(expectedViolation);
+  }
+}

--- a/src/test/resources/proto/validationtest/custom_constraints.proto
+++ b/src/test/resources/proto/validationtest/custom_constraints.proto
@@ -1,0 +1,41 @@
+// Copyright 2023-2024 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package validationtest;
+
+import "buf/validate/validate.proto";
+
+message FieldExpressionRepeatedMessage {
+  repeated Msg val = 1 [(buf.validate.field).cel = {
+    id: "field_expression.repeated.message"
+    message: "test message field_expression.repeated.message"
+    expression: "this.all(e, e.a == 1)"
+  }];
+  message Msg {
+    int32 a = 1;
+  }
+}
+
+message FieldExpressionRepeatedMessageItems {
+  repeated Msg val = 1 [(buf.validate.field).repeated.items.cel = {
+    id: "field_expression.repeated.message.items"
+    message: "test message field_expression.repeated.message.items"
+    expression: "this.a == 1"
+  }];
+  message Msg {
+    int32 a = 1;
+  }
+}


### PR DESCRIPTION
`protovalidate-java` cannot use a CEL expression where `this` represents a repeated message. `EvaluatorBuilder`'s `processFieldExpression` is currently directly using `Decls.newObjectType()` to create an object type based on the name of the message type in the field instead of honoring whether or not the field is repeated and returning a `Decls.newListType()`.

`provalidate` [recently added](https://github.com/bufbuild/protovalidate/pull/329) conformance tests that illustrate this problem. 

To fix this, this PR:

1. Adds JUnit tests and `.proto` that demonstrate the issue.
2. Updates `EvaluatorBuilder`'s `processFieldExpression` to delegate the determination of the CEL type to `DescriptorMappings.getCELType()`, which uses the `FieldDescriptor` to determine the correct type to return. This method requires passing a `forItems` flag stating if the type returned should be the list (or map) type for a field or the type of the items in the collection. Using the [new `nestedRule` property](https://github.com/bufbuild/protovalidate-java/pull/215)'s state provides the value of this flag, [similar to how it's used in `processStandardConstraints`](https://github.com/bufbuild/protovalidate-java/blob/b3cd73121d04182dc989b76902e468f94b5f0b99/src/main/java/build/buf/protovalidate/EvaluatorBuilder.java#L421) to pass the `forItems` flag to `constraintCache.compile()`.
3. Because there were now 7 places where `valueEvaluator.getNestedRule() == null` was used to determine behavior, I moved this comparison into a `hasNestedRule()` method on `ValueEvaluator`, using conformance state to check regression.

Conformance notes:

This PR passes conformance in `protovalidate-java`. 

It has been tested against the conformance suite at the current head of `protovalidate` (which now includes the standard library, so there are many new failures).

Before changes in this PR, there were 137 failures. After, there were 135:

```
BEFORE: FAIL (failed: 137, skipped: 0, passed: 2681, total: 2818)
AFTER : FAIL (failed: 135, skipped: 0, passed: 2683, total: 2818)
```

Running `field_expression/repeated/message` shows that the two conformance tests fixed were for the desired issue:

```
BEFORE: FAIL (failed: 2, skipped: 0, passed: 2, total: 4)
AFTER:  PASS (failed: 0, skipped: 0, passed: 4, total: 4)
```
