### PR TITLE
Fix IPv6 double colon parsing

### DIFF
--- a/conformance/expected-failures.yaml
+++ b/conformance/expected-failures.yaml
@@ -27,13 +27,6 @@ kitchen_sink:
 standard_rules/repeated:
   - items/in/invalid
   - items/not_in/invalid
-library/is_ip:
-  - version/6/invalid/ipv6/7h16_double_colon_1h16
-  - version/6/invalid/ipv6/7h16_double_colon
-  - version/6/invalid/ipv6/double_colon_8h16
-  - version/6/invalid/ipv6/1h16_double_colon_7h16
 standard_rules/well_known_types/duration:
   - in/invalid
   - not in/invalid
-
-

--- a/src/main/java/build/buf/protovalidate/Ipv6.java
+++ b/src/main/java/build/buf/protovalidate/Ipv6.java
@@ -209,7 +209,11 @@ final class Ipv6 {
       break;
     }
 
-    return this.doubleColonSeen || this.pieces.size() == 8;
+    int totalPieces = this.pieces.size();
+    if (this.doubleColonSeen) {
+      return totalPieces < 8;
+    }
+    return totalPieces == 8;
   }
 
   /**


### PR DESCRIPTION
This ports the change from https://github.com/bufbuild/protovalidate-go/pull/224 to this repo to fix double colon parsing for IPv6 addresses.