### PR TITLE
Fix overload declaration for format

### DIFF
--- a/src/main/java/build/buf/protovalidate/CustomDeclarations.java
+++ b/src/main/java/build/buf/protovalidate/CustomDeclarations.java
@@ -160,39 +160,12 @@ final class CustomDeclarations {
 
     // Add 'format' function declaration
     List<Decl.FunctionDecl.Overload> formatOverloads = new ArrayList<>();
-    for (com.google.api.expr.v1alpha1.Type type :
-        Arrays.asList(
-            Decls.String,
-            Decls.Int,
-            Decls.Uint,
-            Decls.Double,
-            Decls.Bytes,
-            Decls.Bool,
-            Decls.Duration,
-            Decls.Timestamp)) {
-      formatOverloads.add(
-          Decls.newInstanceOverload(
-              String.format("format_%s", Types.formatCheckedType(type).toLowerCase(Locale.US)),
-              Arrays.asList(Decls.String, Decls.newListType(type)),
-              Decls.String));
-      formatOverloads.add(
-          Decls.newInstanceOverload(
-              String.format("format_list_%s", Types.formatCheckedType(type).toLowerCase(Locale.US)),
-              Arrays.asList(Decls.String, Decls.newListType(Decls.newListType(type))),
-              Decls.String));
-      formatOverloads.add(
-          Decls.newInstanceOverload(
-              String.format(
-                  "format_bytes_%s", Types.formatCheckedType(type).toLowerCase(Locale.US)),
-              Arrays.asList(Decls.Bytes, Decls.newListType(type)),
-              Decls.Bytes));
-      formatOverloads.add(
-          Decls.newInstanceOverload(
-              String.format(
-                  "format_bytes_list_%s", Types.formatCheckedType(type).toLowerCase(Locale.US)),
-              Arrays.asList(Decls.Bytes, Decls.newListType(Decls.newListType(type))),
-              Decls.Bytes));
-    }
+    formatOverloads.add(
+        Decls.newInstanceOverload(
+            "format_list_dyn",
+            Arrays.asList(Decls.String, Decls.newListType(Decls.Dyn)),
+            Decls.String));
+
     decls.add(Decls.newFunction("format", formatOverloads));
 
     return Collections.unmodifiableList(decls);

--- a/src/main/java/build/buf/protovalidate/Format.java
+++ b/src/main/java/build/buf/protovalidate/Format.java
@@ -22,11 +22,13 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
 import org.projectnessie.cel.common.types.Err.ErrException;
 import org.projectnessie.cel.common.types.IntT;
 import org.projectnessie.cel.common.types.IteratorT;
@@ -199,20 +201,22 @@ final class Format {
     StringBuilder builder = new StringBuilder();
     builder.append('{');
 
-    List<String> entries = new ArrayList<String>();
+    SortedMap<String, String> sorted = new TreeMap<>();
 
     IteratorT iter = val.iterator();
     while (iter.hasNext().booleanValue()) {
       Val key = iter.next();
       String mapKey = formatString(key);
       String mapVal = formatString(val.find(key));
-      entries.add(mapKey + ": " + mapVal);
+      sorted.put(mapKey, mapVal);
     }
 
-    // The formatted string should be sorted by keys
-    Collections.sort(entries);
+    String result =
+        sorted.entrySet().stream()
+            .map(entry -> entry.getKey() + ": " + entry.getValue())
+            .collect(Collectors.joining(", "));
 
-    builder.append(String.join(", ", entries)).append('}');
+    builder.append(result).append('}');
 
     return builder.toString();
   }

--- a/src/main/java/build/buf/protovalidate/Format.java
+++ b/src/main/java/build/buf/protovalidate/Format.java
@@ -22,6 +22,9 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import org.projectnessie.cel.common.types.Err.ErrException;
@@ -132,10 +135,11 @@ final class Format {
   private static String formatString(Val val) {
     TypeEnum type = val.type().typeEnum();
     switch (type) {
-      case Bool:
-        return Boolean.toString(val.booleanValue());
+      case Type:
       case String:
         return val.value().toString();
+      case Bool:
+        return Boolean.toString(val.booleanValue());
       case Int:
       case Uint:
         Optional<String> str = validateNumber(val);
@@ -195,17 +199,21 @@ final class Format {
     StringBuilder builder = new StringBuilder();
     builder.append('{');
 
+    List<String> entries = new ArrayList<String>();
+
     IteratorT iter = val.iterator();
     while (iter.hasNext().booleanValue()) {
       Val key = iter.next();
       String mapKey = formatString(key);
       String mapVal = formatString(val.find(key));
-      builder.append(mapKey).append(": ").append(mapVal);
-      if (iter.hasNext().booleanValue()) {
-        builder.append(", ");
-      }
+      entries.add(mapKey + ": " + mapVal);
     }
-    builder.append('}');
+
+    // The formatted string should be sorted by keys
+    Collections.sort(entries);
+
+    builder.append(String.join(", ", entries)).append('}');
+
     return builder.toString();
   }
 

--- a/src/main/java/build/buf/protovalidate/Format.java
+++ b/src/main/java/build/buf/protovalidate/Format.java
@@ -267,7 +267,7 @@ final class Format {
     } else {
       throw new ErrException(
           "error during formatting: only integers, byte buffers, and strings can be formatted as hex, was given "
-              + typeToString(val));
+              + val.type());
     }
   }
 
@@ -288,7 +288,7 @@ final class Format {
     } else {
       throw new ErrException(
           "error during formatting: decimal clause can only be used on integers, was given "
-              + typeToString(val));
+              + val.type());
     }
   }
 
@@ -299,7 +299,7 @@ final class Format {
     } else {
       throw new ErrException(
           "error during formatting: octal clause can only be used on integers, was given "
-              + typeToString(val));
+              + val.type());
     }
   }
 
@@ -312,7 +312,7 @@ final class Format {
     } else {
       throw new ErrException(
           "error during formatting: only integers and bools can be formatted as binary, was given "
-              + typeToString(val));
+              + val.type());
     }
   }
 
@@ -328,7 +328,7 @@ final class Format {
     } else {
       throw new ErrException(
           "error during formatting: scientific clause can only be used on doubles, was given "
-              + typeToString(val));
+              + val.type());
     }
   }
 
@@ -352,7 +352,7 @@ final class Format {
     } else {
       throw new ErrException(
           "error during formatting: fixed-point clause can only be used on doubles, was given "
-              + typeToString(val));
+              + val.type());
     }
   }
 
@@ -363,10 +363,5 @@ final class Format {
       return Optional.of("-Infinity");
     }
     return Optional.empty();
-  }
-
-  private static String typeToString(Val val) {
-    TypeEnum type = val.type().typeEnum();
-    return type.getName();
   }
 }

--- a/src/test/java/build/buf/protovalidate/FormatTest.java
+++ b/src/test/java/build/buf/protovalidate/FormatTest.java
@@ -60,23 +60,7 @@ class FormatTest {
   private static List<SimpleTest> formatTests;
   private static List<SimpleTest> formatErrorTests;
 
-  private static List<String> SKIPPED_TESTS =
-      Arrays.asList(
-          // Success Tests
-          // found no matching overload for 'format' applied to 'string.(list(type(string)))'
-          "type() support for string",
-          // found no matching overload for 'format' applied to 'string.(list(map(string, dyn)))'
-          "map support for string",
-          // found no matching overload for 'format' applied to 'string.(list(map(dyn, dyn)))'
-          "map support (all key types)",
-          // found no matching overload for 'format' applied to 'string.(list(map(dyn, dyn)))'
-          "dyntype support for maps",
-          // Error Tests
-          // found no matching overload for 'format' applied to
-          // 'string.(list(cel.expr.conformance.proto3.TestAllTypes))'
-          "object not allowed",
-          // found no matching overload for 'format' applied to 'string.(list(map(int, dyn)))'
-          "object inside map");
+  private static List<String> SKIPPED_TESTS = Arrays.asList();
 
   @BeforeAll
   private static void setUp() throws Exception {

--- a/src/test/java/build/buf/protovalidate/FormatTest.java
+++ b/src/test/java/build/buf/protovalidate/FormatTest.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +58,6 @@ class FormatTest {
 
   private static List<SimpleTest> formatTests;
   private static List<SimpleTest> formatErrorTests;
-
-  private static List<String> SKIPPED_TESTS = Arrays.asList();
 
   @BeforeAll
   private static void setUp() throws Exception {
@@ -142,11 +139,9 @@ class FormatTest {
   }
 
   private static Stream<Arguments> getTestStream(List<SimpleTest> tests) {
-    List<Arguments> args = new ArrayList<Arguments>();
+    List<Arguments> args = new ArrayList<>();
     for (SimpleTest test : tests) {
-      if (!SKIPPED_TESTS.contains(test.getName())) {
-        args.add(Arguments.arguments(Named.named(test.getName(), test)));
-      }
+      args.add(Arguments.arguments(Named.named(test.getName(), test)));
     }
 
     return args.stream();
@@ -162,7 +157,7 @@ class FormatTest {
 
   // Builds the variable definitions to be used during evaluation
   private static Map<String, Object> buildVariables(Map<String, ExprValue> bindings) {
-    Map<String, Object> vars = new HashMap<String, Object>();
+    Map<String, Object> vars = new HashMap<>();
     for (Map.Entry<String, ExprValue> entry : bindings.entrySet()) {
       ExprValue exprValue = entry.getValue();
       if (exprValue.hasValue()) {
@@ -192,8 +187,7 @@ class FormatTest {
 
   // Builds the declarations for a given test
   private static List<com.google.api.expr.v1alpha1.Decl> buildDecls(SimpleTest test) {
-    List<com.google.api.expr.v1alpha1.Decl> decls =
-        new ArrayList<com.google.api.expr.v1alpha1.Decl>();
+    List<com.google.api.expr.v1alpha1.Decl> decls = new ArrayList<>();
     for (Decl decl : test.getTypeEnvList()) {
       if (decl.hasIdent()) {
         Decl.IdentDecl ident = decl.getIdent();

--- a/src/test/resources/testdata/string_ext_supplemental.textproto
+++ b/src/test/resources/testdata/string_ext_supplemental.textproto
@@ -11,14 +11,14 @@ section: {
   name: "format"
   test: {
     name: "bytes support for string with invalid utf-8 encoding"
-    expr: '"%s".format([b"\xF0abc\x8C\xF0xyz"])'
+    expr: '"%s".format([b"\\xF0abc\\x8C\\xF0xyz"])'
     value: {
       string_value: '\ufffdabc\ufffdxyz',
     }
   }
   test: {
     name: "bytes support for string with only invalid utf-8 sequences"
-    expr: '"%s".format([b"\xF0\x8C\xF0"])'
+    expr: '"%s".format([b"\\xF0\\x8C\\xF0"])'
     value: {
       string_value: '\ufffd',
     }


### PR DESCRIPTION
After some investigation, it seems the reason some of the cel conformance tests weren't running was because the overload declaration for `format` inside protovalidate-java was too narrow and was only allowing primitive types inside lists.

This simplifies the declaration so that any `DynType` is accepted, which allows maps as well as custom Protobuf types to be passed inside a list to format.