### PR TITLE
Filter buf.gen.yaml files based on protoc version

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,5 +1,5 @@
 version: v2
 clean: true
 plugins:
-  - remote: buf.build/protocolbuffers/java:v31.1
+  - remote: buf.build/protocolbuffers/java:$protocJavaPluginVersion
     out: build/generated/sources/bufgen

--- a/conformance/buf.gen.yaml
+++ b/conformance/buf.gen.yaml
@@ -6,5 +6,5 @@ managed:
     - file_option: java_package_prefix
       value: build
 plugins:
-  - remote: buf.build/protocolbuffers/java:v31.1
+  - remote: buf.build/protocolbuffers/java:$protocJavaPluginVersion
     out: build/generated/sources/bufgen

--- a/conformance/build.gradle.kts
+++ b/conformance/build.gradle.kts
@@ -53,14 +53,23 @@ tasks.register<Exec>("conformance") {
     commandLine(*(listOf(conformanceCLIPath) + conformanceArgs + listOf(conformanceAppScript)).toTypedArray())
 }
 
+tasks.register<Copy>("filterBufGenYaml") {
+    from(".")
+    include("buf.gen.yaml")
+    includeEmptyDirs = false
+    into(layout.buildDirectory.dir("buf-gen-templates"))
+    expand("protocJavaPluginVersion" to "v${libs.versions.protobuf.get().substringAfter('.')}")
+    filteringCharset = "UTF-8"
+}
+
 tasks.register<Exec>("generateConformance") {
-    dependsOn("configureBuf")
+    dependsOn("configureBuf", "filterBufGenYaml")
     description = "Generates sources for the bufbuild/protovalidate-testing module to build/generated/sources/bufgen."
     commandLine(
         buf.asPath,
         "generate",
         "--template",
-        "buf.gen.yaml",
+        "${layout.buildDirectory.get()}/buf-gen-templates/buf.gen.yaml",
         "buf.build/bufbuild/protovalidate-testing:${project.findProperty("protovalidate.version")}",
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,11 +5,6 @@ cel = "0.5.3"
 error-prone = "2.38.0"
 junit = "5.13.0"
 maven-publish = "0.32.0"
-# When updating, make sure to update versions in the following files to match and regenerate code with 'make generate'.
-# - buf.gen.yaml
-# - conformance/buf.gen.yaml
-# - src/test/resources/proto/buf.gen.imports.yaml
-# - src/test/resources/proto/buf.gen.noimports.yaml
 protobuf = "4.31.1"
 
 [libraries]

--- a/src/test/resources/proto/buf.gen.cel.testtypes.yaml
+++ b/src/test/resources/proto/buf.gen.cel.testtypes.yaml
@@ -5,5 +5,5 @@ managed:
     - file_option: java_package
       value: cel.expr.conformance.proto3
 plugins:
-  - remote: buf.build/protocolbuffers/java:v31.1
+  - remote: buf.build/protocolbuffers/java:$protocJavaPluginVersion
     out: build/generated/test-sources/bufgen

--- a/src/test/resources/proto/buf.gen.cel.yaml
+++ b/src/test/resources/proto/buf.gen.cel.yaml
@@ -2,5 +2,5 @@ version: v2
 managed:
   enabled: true
 plugins:
-  - remote: buf.build/protocolbuffers/java:v31.1
+  - remote: buf.build/protocolbuffers/java:$protocJavaPluginVersion
     out: build/generated/test-sources/bufgen

--- a/src/test/resources/proto/buf.gen.imports.yaml
+++ b/src/test/resources/proto/buf.gen.imports.yaml
@@ -5,7 +5,7 @@ managed:
     - file_option: java_package_prefix
       value: com.example.imports
 plugins:
-  - remote: buf.build/protocolbuffers/java:v31.1
+  - remote: buf.build/protocolbuffers/java:$protocJavaPluginVersion
     out: build/generated/test-sources/bufgen
 inputs:
   - directory: src/test/resources/proto

--- a/src/test/resources/proto/buf.gen.noimports.yaml
+++ b/src/test/resources/proto/buf.gen.noimports.yaml
@@ -8,7 +8,7 @@ managed:
     - file_option: java_package_prefix
       value: com.example.noimports
 plugins:
-  - remote: buf.build/protocolbuffers/java:v31.1
+  - remote: buf.build/protocolbuffers/java:$protocJavaPluginVersion
     out: build/generated/test-sources/bufgen
 inputs:
   - directory: src/main/resources


### PR DESCRIPTION
Update the buf.gen.yaml files to filter based on the protoc version, removing a manual step required when updating to newer protoc versions.