### PR TITLE
Update to protovalidate 0.12.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version of buf.build/bufbuild/protovalidate to use.
-protovalidate.version = v0.11.1
+protovalidate.version = v0.12.0
 
 # Arguments to the protovalidate-conformance CLI
 protovalidate.conformance.args = --strict_message --strict_error --expected_failures=expected-failures.yaml

--- a/src/main/resources/buf/validate/validate.proto
+++ b/src/main/resources/buf/validate/validate.proto
@@ -190,6 +190,7 @@ message FieldRules {
   //   - proto2 scalar fields (both optional and required)
   // - proto3 scalar fields must be non-zero to be considered populated
   // - repeated and map fields must be non-empty to be considered populated
+  // - map keys/values and repeated items are always considered populated
   //
   // ```proto
   // message MyMessage {
@@ -625,7 +626,7 @@ message FloatRules {
   // message MyFloat {
   //   float value = 1 [
   //     (buf.validate.field).float.example = 1.0,
-  //     (buf.validate.field).float.example = "Infinity"
+  //     (buf.validate.field).float.example = inf
   //   ];
   // }
   // ```
@@ -846,7 +847,7 @@ message DoubleRules {
   // message MyDouble {
   //   double value = 1 [
   //     (buf.validate.field).double.example = 1.0,
-  //     (buf.validate.field).double.example = "Infinity"
+  //     (buf.validate.field).double.example = inf
   //   ];
   // }
   // ```
@@ -4241,6 +4242,9 @@ message RepeatedRules {
   // in the field. Even for repeated message fields, validation is executed
   // against each item unless skip is explicitly specified.
   //
+  // Note that repeated items are always considered populated. The `required`
+  // rule does not apply.
+  //
   // ```proto
   // message MyRepeated {
   //   // The items in the field `value` must follow the specified rules.
@@ -4299,6 +4303,9 @@ message MapRules {
 
   //Specifies the rules to be applied to each key in the field.
   //
+  // Note that map keys are always considered populated. The `required`
+  // rule does not apply.
+  //
   // ```proto
   // message MyMap {
   //   // The keys in the field `value` must follow the specified rules.
@@ -4315,6 +4322,9 @@ message MapRules {
   //Specifies the rules to be applied to the value of each key in the
   // field. Message values will still have their validations evaluated unless
   //skip is specified here.
+  //
+  // Note that map values are always considered populated. The `required`
+  // rule does not apply.
   //
   // ```proto
   // message MyMap {
@@ -4351,7 +4361,9 @@ message AnyRules {
   // ```proto
   // message MyAny {
   //   //  The `value` field must have a `type_url` equal to one of the specified values.
-  //   google.protobuf.Any value = 1 [(buf.validate.field).any.in = ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]];
+  //   google.protobuf.Any value = 1 [(buf.validate.field).any = {
+  //       in: ["type.googleapis.com/MyType1", "type.googleapis.com/MyType2"]
+  //   }];
   // }
   // ```
   repeated string in = 2;
@@ -4360,8 +4372,10 @@ message AnyRules {
   //
   // ```proto
   // message MyAny {
-  //   // The field `value` must not have a `type_url` equal to any of the specified values.
-  //   google.protobuf.Any value = 1 [(buf.validate.field).any.not_in = ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]];
+  //   //  The `value` field must not have a `type_url` equal to any of the specified values.
+  //   google.protobuf.Any value = 1 [(buf.validate.field).any = {
+  //       not_in: ["type.googleapis.com/ForbiddenType1", "type.googleapis.com/ForbiddenType2"]
+  //   }];
   // }
   // ```
   repeated string not_in = 3;
@@ -4783,7 +4797,6 @@ message TimestampRules {
   //   ];
   // }
   // ```
-
   repeated google.protobuf.Timestamp example = 10 [(predefined).cel = {
     id: "timestamp.example"
     expression: "true"

--- a/src/test/java/build/buf/protovalidate/FormatTest.java
+++ b/src/test/java/build/buf/protovalidate/FormatTest.java
@@ -60,7 +60,7 @@ class FormatTest {
   private static List<SimpleTest> formatErrorTests;
 
   @BeforeAll
-  private static void setUp() throws Exception {
+  public static void setUp() throws Exception {
     // The test data from the cel-spec conformance tests
     List<SimpleTestSection> celSpecSections =
         loadTestData("src/test/resources/testdata/string_ext_" + CEL_SPEC_VERSION + ".textproto");


### PR DESCRIPTION
This updates protovalidate-java to the new Protovalidate v0.12.0 release. 

The v0.12.0 release added [new conformance tests](https://github.com/bufbuild/protovalidate/pull/365) for validating rules on incorrect field types. As a result, this uncovered the same bug that was present in protovalidate-go (see https://github.com/bufbuild/protovalidate-go/pull/247 for context).
