### PR TITLE
Fix typo in CONTRIBUTING.md file URL

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -175,6 +175,6 @@ working together to make `protovalidate` the best it can be.
 
 [file-bug]: https://github.com/bufbuild/protovalidate-java/issues/new?assignees=&labels=Bug&template=bug_report.md&title=%5BBUG%5D
 
-[file-feature-request]: https://github.com/bufbuild/protovalidate=java/issues/new?assignees=&labels=Feature&template=feature_request.md&title=%5BFeature+Request%5D
+[file-feature-request]: https://github.com/bufbuild/protovalidate-java/issues/new?assignees=&labels=Feature&template=feature_request.md&title=%5BFeature+Request%5D
 
 [cel-spec]: https://github.com/google/cel-spec


### PR DESCRIPTION
This PR fixes a typo in the feature request URL within the `.github/CONTRIBUTING.md` file. The URL incorrectly used an equals sign (`=`) instead of a hyphen (`-`) in the repository name.