### PR TITLE
Add support for CEL 0.11.1

### DIFF
--- a/conformance/src/test/java/build/buf/protovalidate/ValidatorTest.java
+++ b/conformance/src/test/java/build/buf/protovalidate/ValidatorTest.java
@@ -24,6 +24,7 @@ import build.buf.validate.conformance.cases.BoolConstTrue;
 import build.buf.validate.conformance.cases.BytesContains;
 import build.buf.validate.conformance.cases.BytesIn;
 import build.buf.validate.conformance.cases.DurationGTELTE;
+import build.buf.validate.conformance.cases.DurationIn;
 import build.buf.validate.conformance.cases.Embed;
 import build.buf.validate.conformance.cases.EnumDefined;
 import build.buf.validate.conformance.cases.Fixed32LT;
@@ -263,6 +264,14 @@ public class ValidatorTest {
   @Test
   public void testStringLenEmoji() throws ValidationException {
     StringLen test = StringLen.newBuilder().setVal("😅😄👾").build();
+    ValidationResult validate = validator.validate(test);
+    assertThat(validate.getViolations()).isEmpty();
+    assertThat(validate.isSuccess()).isTrue();
+  }
+
+  @Test
+  public void testDurationIn() throws ValidationException {
+    DurationIn test = DurationIn.newBuilder().setVal(Duration.newBuilder().setSeconds(1)).build();
     ValidationResult validate = validator.validate(test);
     assertThat(validate.getViolations()).isEmpty();
     assertThat(validate.isSuccess()).isTrue();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 assertj = "3.27.6"
 buf = "1.59.0"
-cel = "0.11.0"
+cel = "0.11.1"
 error-prone = "2.43.0"
 junit = "5.14.0"
 maven-publish = "0.34.0"


### PR DESCRIPTION
CEL 0.11.1 adds support for native java.time.Instant (WKT Timestamp) and java.time.Duration (WKT Duration). Update protovalidate-java to work with the new functionality, which requires that we convert types to the native representations as we're configuring the CEL runtime with `evaluateCanonicalTypesToNativeValues(true)`.