### PR TITLE
Add ability to depend on an arbitrary upstream commit

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -166,13 +166,19 @@ tasks.register("generateTestSources") {
     description = "Generates code with buf generate for unit tests"
 }
 
+val semverRegex = Regex("""^v\d+\.\d+\.\d+(?:-.+)?$""")
 tasks.register<Exec>("exportProtovalidateModule") {
     dependsOn("configureBuf")
     description = "Exports the bufbuild/protovalidate module sources to src/main/resources."
+    val version = "${project.findProperty("protovalidate.version")}"
+    var input = "buf.build/bufbuild/protovalidate:$version"
+    if (!semverRegex.matches(version)) {
+        input = "https://github.com/bufbuild/protovalidate.git#subdir=proto/protovalidate,ref=$version"
+    }
     commandLine(
         buf.asPath,
         "export",
-        "buf.build/bufbuild/protovalidate:${project.findProperty("protovalidate.version")}",
+        input,
         "--output",
         "src/main/resources",
     )

--- a/conformance/build.gradle.kts
+++ b/conformance/build.gradle.kts
@@ -62,15 +62,21 @@ tasks.register<Copy>("filterBufGenYaml") {
     filteringCharset = "UTF-8"
 }
 
+val semverRegex = Regex("""^v\d+\.\d+\.\d+(?:-.+)?$""")
 tasks.register<Exec>("generateConformance") {
     dependsOn("configureBuf", "filterBufGenYaml")
     description = "Generates sources for the bufbuild/protovalidate-testing module to build/generated/sources/bufgen."
+    val version = "${project.findProperty("protovalidate.version")}"
+    var input = "buf.build/bufbuild/protovalidate-testing:$version"
+    if (!semverRegex.matches(version)) {
+        input = "https://github.com/bufbuild/protovalidate.git#subdir=proto/protovalidate-testing,ref=$version"
+    }
     commandLine(
         buf.asPath,
         "generate",
         "--template",
         "${layout.buildDirectory.get()}/buf-gen-templates/buf.gen.yaml",
-        "buf.build/bufbuild/protovalidate-testing:${project.findProperty("protovalidate.version")}",
+        input,
     )
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Version of buf.build/bufbuild/protovalidate to use.
-protovalidate.version = v1.1.0
+protovalidate.version = 895eefca6d1346f742fc18b9983d40478820906d
 
 # Arguments to the protovalidate-conformance CLI
 protovalidate.conformance.args = --strict_message --strict_error --expected_failures=expected-failures.yaml

--- a/src/main/resources/buf/validate/validate.proto
+++ b/src/main/resources/buf/validate/validate.proto
@@ -14,6 +14,34 @@
 
 syntax = "proto2";
 
+// [Protovalidate](https://protovalidate.com/) is the semantic validation library for Protobuf.
+// It provides standard annotations to validate common rules on messages and fields, as well as the ability to use [CEL](https://cel.dev) to write custom rules.
+// It's the next generation of [protoc-gen-validate](https://github.com/bufbuild/protoc-gen-validate).
+//
+// This package provides the options, messages, and enums that power Protovalidate.
+// Apply its options to messages, fields, and oneofs in your Protobuf schemas to add validation rules:
+//
+// ```proto
+// message User {
+//   string id = 1 [(buf.validate.field).string.uuid = true];
+//   string first_name = 2 [(buf.validate.field).string.max_len = 64];
+//   string last_name = 3 [(buf.validate.field).string.max_len = 64];
+//
+//   option (buf.validate.message).cel = {
+//     id: "first_name_requires_last_name"
+//     message: "last_name must be present if first_name is present"
+//     expression: "!has(this.first_name) || has(this.last_name)"
+//   };
+// }
+// ```
+//
+// These rules are enforced at runtime by language-specific libraries.
+// See the [developer quickstart](https://protovalidate.com/quickstart/) to get started, or go directly to the runtime library for your language:
+// [Go](https://github.com/bufbuild/protovalidate-go)
+// [JavaScript/TypeScript](https://github.com/bufbuild/protovalidate-es),
+// [Java](https://github.com/bufbuild/protovalidate-java),
+// [Python](https://github.com/bufbuild/protovalidate-python),
+// or [C++](https://github.com/bufbuild/protovalidate-cc).
 package buf.validate;
 
 import "google/protobuf/descriptor.proto";


### PR DESCRIPTION
This also changes the protovalidate version to the latest commit on main. This will help reduce the feedback loop by making it quick to match changes in upstream.