### PR TITLE
Fix cache key mismatch in RuleCache.compileRule

### DIFF
--- a/src/main/java/build/buf/protovalidate/RuleCache.java
+++ b/src/main/java/build/buf/protovalidate/RuleCache.java
@@ -144,7 +144,7 @@ final class RuleCache {
       FieldDescriptor ruleFieldDesc,
       Message message)
       throws CompilationException {
-    List<CelRule> celRules = descriptorMap.get(fieldDescriptor);
+    List<CelRule> celRules = descriptorMap.get(ruleFieldDesc);
     if (celRules != null) {
       return celRules;
     }


### PR DESCRIPTION
## Summary

`RuleCache.compileRule()` stores entries in `descriptorMap` keyed by `ruleFieldDesc` (the rule field, e.g. `StringRules.pattern`), but the lookup at the top of the method uses `fieldDescriptor` (the user's field being validated).

The read key and write key never agree, so cached `CelRule` lists are never reused across different user fields that share the same predefined rule — every call falls through and re-builds the AST.

This PR changes the lookup to use `ruleFieldDesc` so it matches the store.

## Test plan

- [x] Existing unit tests pass (`./gradlew test`)
- [x] Existing conformance tests pass