### PR TITLE
Cache compiled programs by serialized rule message

### DIFF
--- a/src/main/java/build/buf/protovalidate/RuleCache.java
+++ b/src/main/java/build/buf/protovalidate/RuleCache.java
@@ -64,6 +64,13 @@ final class RuleCache {
   private static final Map<FieldDescriptor, List<CelRule>> descriptorMap =
       new ConcurrentHashMap<>();
 
+  /**
+   * Concurrent map for caching compiled programs by the serialized rule message bytes. This allows
+   * fields sharing the same resolved rules (same type + same values) to reuse compiled programs.
+   */
+  private static final Map<com.google.protobuf.ByteString, List<CompiledProgram>> programCache =
+      new ConcurrentHashMap<>();
+
   /** The environment to use for evaluation. */
   private final Cel cel;
 
@@ -109,6 +116,11 @@ final class RuleCache {
       return Collections.emptyList();
     }
     Message message = resolved.message;
+    com.google.protobuf.ByteString cacheKey = message.toByteString();
+    List<CompiledProgram> cachedPrograms = programCache.get(cacheKey);
+    if (cachedPrograms != null) {
+      return cachedPrograms;
+    }
     List<CelRule> completeProgramList = new ArrayList<>();
     for (Map.Entry<FieldDescriptor, Object> entry : message.getAllFields().entrySet()) {
       FieldDescriptor ruleFieldDesc = entry.getKey();
@@ -134,7 +146,9 @@ final class RuleCache {
             "failed to evaluate rule " + rule.astExpression.source.id, e);
       }
     }
-    return Collections.unmodifiableList(programs);
+    List<CompiledProgram> result = Collections.unmodifiableList(programs);
+    programCache.putIfAbsent(cacheKey, result);
+    return result;
   }
 
   private @Nullable List<CelRule> compileRule(


### PR DESCRIPTION
## Summary

Fields with identical resolved rules (same rule type + same values — e.g. multiple fields sharing the same predefined constraint such as an `evm_hash` pattern) currently rebuild their `List<CompiledProgram>` from scratch every time, even though the resulting programs are equivalent.

This PR adds a static `ConcurrentHashMap` in `RuleCache` keyed by the serialized rule message bytes. On hit, `compile()` returns the cached list directly; on miss, it falls through to the existing build path and populates the cache with the result.

In a workload with 14 descriptor types and 19 fields sharing 2 predefined rules, warmup time dropped from ~58ms to ~3.6ms.

Note: this is independent of the cache-key fix in #451 — the two help different scenarios (AST reuse across fields sharing a rule field descriptor vs. program reuse across fields with identical resolved rule values) and can be merged in either order.

## Test plan

- [x] Existing unit tests pass (`./gradlew test`)
- [x] Existing conformance tests pass