### PR TITLE
Move BSR login into the buf-action step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,9 +34,7 @@ jobs:
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           setup_only: true
-      - env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: echo ${BUF_TOKEN} | buf registry login buf.build --token-stdin
+          token: ${{ secrets.BUF_TOKEN }}
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Lint

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -34,9 +34,7 @@ jobs:
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           setup_only: true
-      - env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: echo ${BUF_TOKEN} | buf registry login buf.build --token-stdin
+          token: ${{ secrets.BUF_TOKEN }}
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
       - name: Test conformance

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Cache Go Modules
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -24,23 +23,17 @@ jobs:
           key: ${{ runner.os }}-gomod-ci-${{ hashFiles('gradle.properties', 'gradle/libs.versions.toml') }}
           restore-keys:
             ${{ runner.os }}-gomod-ci-
-
       - name: Set up JDK
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: '21'
-
       - uses: bufbuild/buf-action@fd21066df7214747548607aaa45548ba2b9bc1ff # v1.4.0
         with:
           setup_only: true
-      - env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: echo ${BUF_TOKEN} | buf registry login buf.build --token-stdin
-
+          token: ${{ secrets.BUF_TOKEN }}
       - name: Validate Gradle Wrapper
         uses: gradle/actions/wrapper-validation@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
-
       - name: Configure GPG signing & publish
         env:
           GPG_KEY: ${{ secrets.GPG_KEY }}


### PR DESCRIPTION
PRs opened from forks currently fail as the BUF_TOKEN secret isn't available. Update the workflows to move BSR login into the buf-action step, which gracefully handles an empty token and skips authentication.