### PR TITLE
Skip the now binding when no program references it

### DIFF
--- a/src/main/java/build/buf/protovalidate/AstExpression.java
+++ b/src/main/java/build/buf/protovalidate/AstExpression.java
@@ -18,6 +18,8 @@ import build.buf.protovalidate.exceptions.CompilationException;
 import dev.cel.common.CelAbstractSyntaxTree;
 import dev.cel.common.CelValidationException;
 import dev.cel.common.CelValidationResult;
+import dev.cel.common.ast.CelExpr.ExprKind;
+import dev.cel.common.navigation.CelNavigableAst;
 import dev.cel.common.types.CelKind;
 import dev.cel.compiler.CelCompiler;
 
@@ -66,5 +68,15 @@ final class AstExpression {
               "Expression outputs, wanted either bool or string: %s %s", expr.id, outKind));
     }
     return new AstExpression(ast, expr);
+  }
+
+  /** Returns true if the AST references the given identifier name anywhere in its tree. */
+  static boolean referencesIdentifier(CelAbstractSyntaxTree ast, String name) {
+    return CelNavigableAst.fromAst(ast)
+        .getRoot()
+        .allNodes()
+        .anyMatch(
+            node ->
+                node.getKind() == ExprKind.Kind.IDENT && node.expr().ident().name().equals(name));
   }
 }

--- a/src/main/java/build/buf/protovalidate/CelPrograms.java
+++ b/src/main/java/build/buf/protovalidate/CelPrograms.java
@@ -28,6 +28,13 @@ final class CelPrograms implements Evaluator {
   private final List<CompiledProgram> programs;
 
   /**
+   * Whether any program in {@link #programs} references the {@code now} variable. Computed once at
+   * construction so {@link #evaluate} can skip the {@link NowVariable} wrapper when no program
+   * needs it.
+   */
+  private final boolean anyUsesNow;
+
+  /**
    * Constructs a new {@link CelPrograms}.
    *
    * @param compiledPrograms The programs to execute.
@@ -35,6 +42,14 @@ final class CelPrograms implements Evaluator {
   CelPrograms(@Nullable ValueEvaluator valueEvaluator, List<CompiledProgram> compiledPrograms) {
     this.helper = new RuleViolationHelper(valueEvaluator);
     this.programs = compiledPrograms;
+    boolean anyUsesNow = false;
+    for (CompiledProgram program : compiledPrograms) {
+      if (program.usesNow()) {
+        anyUsesNow = true;
+        break;
+      }
+    }
+    this.anyUsesNow = anyUsesNow;
   }
 
   @Override
@@ -45,7 +60,7 @@ final class CelPrograms implements Evaluator {
   @Override
   public List<RuleViolation.Builder> evaluate(Value val, boolean failFast)
       throws ExecutionException {
-    CelVariableResolver bindings = Variable.newThisVariable(val.value(Object.class));
+    CelVariableResolver bindings = Variable.newThisVariable(val.value(Object.class), anyUsesNow);
     List<RuleViolation.Builder> violations = new ArrayList<>();
     for (CompiledProgram program : programs) {
       RuleViolation.Builder violation = program.eval(val, bindings);

--- a/src/main/java/build/buf/protovalidate/CompiledProgram.java
+++ b/src/main/java/build/buf/protovalidate/CompiledProgram.java
@@ -44,6 +44,9 @@ final class CompiledProgram {
    */
   @Nullable private final CelVariableResolver globals;
 
+  /** Whether the compiled expression references the {@code now} variable. */
+  private final boolean usesNow;
+
   /**
    * Constructs a new {@link CompiledProgram}.
    *
@@ -51,18 +54,25 @@ final class CompiledProgram {
    * @param source The original expression that was compiled into the program.
    * @param rulePath The field path from the FieldRules to the rule value.
    * @param ruleValue The rule value.
+   * @param usesNow Whether the source expression references the {@code now} variable.
    */
   CompiledProgram(
       Program program,
       Expression source,
       @Nullable FieldPath rulePath,
       @Nullable Value ruleValue,
-      @Nullable CelVariableResolver globals) {
+      @Nullable CelVariableResolver globals,
+      boolean usesNow) {
     this.program = program;
     this.source = source;
     this.rulePath = rulePath;
     this.ruleValue = ruleValue;
     this.globals = globals;
+    this.usesNow = usesNow;
+  }
+
+  boolean usesNow() {
+    return usesNow;
   }
 
   /**

--- a/src/main/java/build/buf/protovalidate/EvaluatorBuilder.java
+++ b/src/main/java/build/buf/protovalidate/EvaluatorBuilder.java
@@ -544,13 +544,16 @@ final class EvaluatorBuilder {
               FieldPath.newBuilder().addElements(fieldPathElement.toBuilder().setIndex(i)).build();
         }
         try {
+          boolean usesNow =
+              AstExpression.referencesIdentifier(astExpression.ast, NowVariable.NOW_NAME);
           compiledPrograms.add(
               new CompiledProgram(
                   cel.createProgram(astExpression.ast),
                   astExpression.source,
                   rulePath,
                   new MessageValue(rules.get(i)),
-                  null));
+                  null,
+                  usesNow));
         } catch (CelEvaluationException e) {
           throw new CompilationException("failed to evaluate rule " + rules.get(i).getId(), e);
         }

--- a/src/main/java/build/buf/protovalidate/RuleCache.java
+++ b/src/main/java/build/buf/protovalidate/RuleCache.java
@@ -45,13 +45,19 @@ final class RuleCache {
     final Program program;
     final FieldDescriptor field;
     final FieldPath rulePath;
+    final boolean usesNow;
 
     private CelRule(
-        AstExpression astExpression, Program program, FieldDescriptor field, FieldPath rulePath) {
+        AstExpression astExpression,
+        Program program,
+        FieldDescriptor field,
+        FieldPath rulePath,
+        boolean usesNow) {
       this.astExpression = astExpression;
       this.program = program;
       this.field = field;
       this.rulePath = rulePath;
+      this.usesNow = usesNow;
     }
   }
 
@@ -129,7 +135,8 @@ final class RuleCache {
               rule.astExpression.source,
               rule.rulePath,
               new ObjectValue(rule.field, fieldValue),
-              Variable.newRuleVariable(message, ProtoAdapter.toCel(rule.field, fieldValue))));
+              Variable.newRuleVariable(message, ProtoAdapter.toCel(rule.field, fieldValue)),
+              rule.usesNow));
     }
     return Collections.unmodifiableList(programs);
   }
@@ -187,7 +194,9 @@ final class RuleCache {
         throw new CompilationException(
             "failed to create program for rule " + astExpression.source.id, e);
       }
-      celRules.add(new CelRule(astExpression, program, ruleFieldDesc, rulePath));
+      boolean usesNow =
+          AstExpression.referencesIdentifier(astExpression.ast, NowVariable.NOW_NAME);
+      celRules.add(new CelRule(astExpression, program, ruleFieldDesc, rulePath, usesNow));
     }
     return celRules;
   }

--- a/src/main/java/build/buf/protovalidate/Variable.java
+++ b/src/main/java/build/buf/protovalidate/Variable.java
@@ -45,14 +45,19 @@ final class Variable implements CelVariableResolver {
   }
 
   /**
-   * Creates a "this" variable.
+   * Creates a resolver for the {@code this} variable. When {@code includeNow} is false the {@code
+   * now} resolver and the hierarchical wrapper are skipped — three allocations become one.
    *
-   * @param val the value.
-   * @return {@link Variable}.
+   * @param val the value bound to {@code this}.
+   * @param includeNow whether the resolver should also expose the {@code now} variable.
+   * @return a {@link CelVariableResolver} bound to {@code this} (and {@code now} when requested).
    */
-  static CelVariableResolver newThisVariable(@Nullable Object val) {
-    return CelVariableResolver.hierarchicalVariableResolver(
-        new NowVariable(), new Variable(THIS_NAME, val));
+  static CelVariableResolver newThisVariable(@Nullable Object val, boolean includeNow) {
+    Variable thisVar = new Variable(THIS_NAME, val);
+    if (!includeNow) {
+      return thisVar;
+    }
+    return CelVariableResolver.hierarchicalVariableResolver(new NowVariable(), thisVar);
   }
 
   /**


### PR DESCRIPTION
## Summary

`Variable.newThisVariable` always allocated three objects per field evaluation: a `NowVariable`, the `this` `Variable`, and a `hierarchicalVariableResolver` wrapping them. Almost no rule expression references the `now` identifier, so the wrapper layer is pure waste in the common case.

This PR walks each compiled CEL AST once at build time (via `CelNavigableAst`) and records whether it references `now`. `CelPrograms` aggregates that flag across its program list at construction; when nothing in the list needs `now`, `Variable.newThisVariable` returns a single bare `Variable("this", val)` instead of the three-object stack — three allocations become one per field eval.

The flag lives on `CompiledProgram` so future construction sites (e.g. user-defined `cel` rules) get the same treatment automatically.

## Benchmark results

Steady-state validate() benchmarks, measured with a standalone `ThreadMXBean`-based runner (5 forks × 200K iterations each, after a 250K-iteration warmup) so we can report **CPU time** alongside wall time and confirm the savings are real CPU work, not just GC offload.

```
benchmark               wall_ns/op      cpu_ns/op   wall Δ   cpu Δ
validateSimple        1227.91 → 1193.03  1215.65 → 1178.89  -2.8%  -3.0%
validateManyUnruled    535.17 →  484.19   528.04 →  480.21  -9.5%  -9.1%
validateRepeatedRule 10643.32 → 10419.12 10574.64 → 10373.57 -2.1%  -1.9%
validateRegexPattern  1645.76 → 1582.47  1639.84 → 1579.18  -3.9%  -3.7%
validateNumericRange 17806.97 → 17206.64 17731.53 → 17137.54 -3.4%  -3.3%
```

`cpu/wall ≈ 0.99` across the board (these benchmarks are fully CPU-bound), and the CPU delta tracks the wall delta within ~0.2pp. The largest relative win is on `validateManyUnruled` — schemas with many fields and few rules are common, and the per-field wrapper overhead is a bigger fraction of total work there.

## Test plan

- [x] `./gradlew test` — full unit + conformance suite passes.
- [x] Benchmarks above were run on JDK 21 against the same upstream `main` baseline.