### PR TITLE
Use the CEL planner runtime

### DIFF
--- a/src/main/java/build/buf/protovalidate/ValidateLibrary.java
+++ b/src/main/java/build/buf/protovalidate/ValidateLibrary.java
@@ -18,15 +18,21 @@ import com.google.re2j.Pattern;
 import dev.cel.bundle.Cel;
 import dev.cel.bundle.CelFactory;
 import dev.cel.checker.CelCheckerBuilder;
+import dev.cel.checker.CelCheckerLegacyImpl;
 import dev.cel.checker.CelStandardDeclarations;
 import dev.cel.common.CelOptions;
 import dev.cel.common.CelVarDecl;
 import dev.cel.common.types.SimpleType;
+import dev.cel.compiler.CelCompiler;
+import dev.cel.compiler.CelCompilerImpl;
 import dev.cel.compiler.CelCompilerLibrary;
 import dev.cel.extensions.CelExtensions;
 import dev.cel.parser.CelParserBuilder;
+import dev.cel.parser.CelParserImpl;
 import dev.cel.parser.CelStandardMacro;
+import dev.cel.runtime.CelRuntime;
 import dev.cel.runtime.CelRuntimeBuilder;
+import dev.cel.runtime.CelRuntimeImpl;
 import dev.cel.runtime.CelRuntimeLibrary;
 import dev.cel.runtime.CelStandardFunctions;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,7 +44,8 @@ import java.util.concurrent.ConcurrentMap;
  */
 final class ValidateLibrary implements CelCompilerLibrary, CelRuntimeLibrary {
 
-  private static final CelOptions CEL_OPTIONS = CelOptions.DEFAULT;
+  private static final CelOptions CEL_OPTIONS =
+      CelOptions.current().enableHeterogeneousNumericComparisons(true).build();
 
   private final ConcurrentMap<String, Pattern> patternCache = new ConcurrentHashMap<>();
 
@@ -47,22 +54,32 @@ final class ValidateLibrary implements CelCompilerLibrary, CelRuntimeLibrary {
 
   static Cel newCel() {
     ValidateLibrary validateLibrary = new ValidateLibrary();
-    return CelFactory.standardCelBuilder()
-        .setOptions(CEL_OPTIONS)
-        // Drop stdlib matches; CustomOverload provides a caching replacement.
-        // Ref: https://github.com/google/cel-java/issues/1038
-        .setStandardEnvironmentEnabled(false)
-        .setStandardDeclarations(
-            CelStandardDeclarations.newBuilder()
-                .excludeFunctions(CelStandardDeclarations.StandardFunction.MATCHES)
-                .build())
-        .setStandardFunctions(
-            CelStandardFunctions.newBuilder()
-                .excludeFunctions(CelStandardFunctions.StandardFunction.MATCHES)
-                .build())
-        .addCompilerLibraries(validateLibrary, CelExtensions.strings())
-        .addRuntimeLibraries(validateLibrary, CelExtensions.strings())
-        .build();
+    // Wired by hand instead of via plannerCelBuilder(): CelRuntimeImpl directs callers to subset
+    // stdlib via setStandardFunctions rather than setStandardEnvironmentEnabled, so the runtime
+    // does that while the checker uses setStandardEnvironmentEnabled(false).
+    CelCompiler compiler =
+        CelCompilerImpl.newBuilder(
+                CelParserImpl.newBuilder(),
+                CelCheckerLegacyImpl.newBuilder().setStandardEnvironmentEnabled(false))
+            .setOptions(CEL_OPTIONS)
+            // Drop stdlib matches; CustomOverload provides a caching replacement.
+            // Ref: https://github.com/google/cel-java/issues/1038
+            .setStandardDeclarations(
+                CelStandardDeclarations.newBuilder()
+                    .excludeFunctions(CelStandardDeclarations.StandardFunction.MATCHES)
+                    .build())
+            .addLibraries(validateLibrary, CelExtensions.strings())
+            .build();
+    CelRuntime runtime =
+        CelRuntimeImpl.newBuilder()
+            .setOptions(CEL_OPTIONS)
+            .setStandardFunctions(
+                CelStandardFunctions.newBuilder()
+                    .excludeFunctions(CelStandardFunctions.StandardFunction.MATCHES)
+                    .build())
+            .addLibraries(validateLibrary, CelExtensions.strings())
+            .build();
+    return CelFactory.combine(compiler, runtime);
   }
 
   @Override


### PR DESCRIPTION
Moves protovalidate-java's CEL setup from the deprecated standard runtime to the planner runtime.

## Notable callouts

- Wire the compiler and runtime by hand rather than through `plannerCelBuilder()`. `CelRuntimeImpl` directs callers to subset the standard library via `setStandardFunctions` rather than `setStandardEnvironmentEnabled`, so the runtime drops stdlib `matches` that way while the checker continues to use `setStandardEnvironmentEnabled(false)`. This keeps `CustomOverload`'s caching `matches` replacement (cel-java#1038).
- Set `CelOptions.current().enableHeterogeneousNumericComparisons(true)`, which `CelRuntimeImpl` requires.
- Update `cel-java` to 0.13.1 preparing to support alternative Protobuf runtimes.

## Related work:

- cel-java: 0.13.1 carries the CelValue-path fixes this work relies on (fixed32/64 treated as unsigned; FieldMask navigable as a message, google/cel-java#1074).
- protovalidate-java: #480 introduces `MessageReflector` to support alternative Protobuf runtimes, which builds on this runtime change (supersedes #202).
- protokt: open-toast/protokt#402 is the downstream consumer that validates protokt messages through `MessageReflector` on this planner runtime.

## Testing

`./gradlew :conformance:conformance` passes.
